### PR TITLE
Bug/submit

### DIFF
--- a/app/api/upload/route.ts
+++ b/app/api/upload/route.ts
@@ -32,8 +32,7 @@ export async function POST(request: NextRequest) {
 
     const blobServiceClient = new BlobServiceClient(`https://${account}.blob.core.windows.net/?${sas}`);
     const containerClient = blobServiceClient.getContainerClient(container);
-    const sanitizedFileName = file.name.replace(/[^a-zA-Z0-9.\-]/g, '');
-    const uniqueName = `${uuidv4()}-${sanitizedFileName}`;
+    const uniqueName = `${uuidv4()}`;
     const blockBlobClient = containerClient.getBlockBlobClient(uniqueName);
 
     await blockBlobClient.uploadFile(tempFilePath, {

--- a/prisma/prismaClient.ts
+++ b/prisma/prismaClient.ts
@@ -1,20 +1,17 @@
 import { PrismaClient } from '@prisma/client';
 
-// Define prisma client with connection pooling and SSL configuration
-const prismaClientSingleton = () => {
-  return new PrismaClient({
-    datasources: {
-      db: {
-        url: process.env.DATABASE_URL,
-      },
-    },
-    // Enable connection pooling in production
-    log: process.env.NODE_ENV === 'development' ? ['query', 'error', 'warn'] : ['error'],
-  });
-};
+let prisma: PrismaClient;
 
-// Use global variable to avoid multiple instances in development
-const globalForPrisma = global as unknown as { prisma: PrismaClient };
-export const prisma = globalForPrisma.prisma || prismaClientSingleton();
+if (process.env.NODE_ENV === 'production') {
+  prisma = new PrismaClient();
+} else {
+  // @ts-ignore
+  if (!global.prisma) {
+    // @ts-ignore
+    global.prisma = new PrismaClient();
+  }
+  // @ts-ignore
+  prisma = global.prisma;
+}
 
-if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma;
+export { prisma };


### PR DESCRIPTION
This pull request introduces two significant changes: one simplifies file naming in an Azure Blob Storage upload function, and the other refactors the Prisma Client initialization to improve compatibility with different environments.

### Azure Blob Storage Upload Improvements:
* [`app/api/upload/route.ts`](diffhunk://#diff-d6f2e1330bd21210549d263dde51d9b36a44b16f644baebe704a128ddf5394f5L35-R35): Removed the sanitization step for uploaded file names and now generates a unique name using only a UUID. This ensures file names are universally unique without relying on the original file name.

### Prisma Client Refactor:
* [`prisma/prismaClient.ts`](diffhunk://#diff-08f424a02007617f89e05fe7af9e14a51278ffc50c577471744a9e8f6f83c03eL3-R17): Refactored the Prisma Client initialization to use a global singleton pattern in non-production environments, reducing the risk of creating multiple instances during development. Removed the previous connection pooling and SSL configuration logic.