### PR TITLE
Feat/change states

### DIFF
--- a/app/(admin)/admin/projects/page.tsx
+++ b/app/(admin)/admin/projects/page.tsx
@@ -92,10 +92,11 @@ export default function ProjectManagement() {
     setApproveDialog(true);
   };
 
-  const handleReject = (project: PendingProject) => {
+  const handleReject = (project: PendingProject | ApprovedProject) => {
     setCurrentProject(project);
     setRejectDialog(true);
   };
+
 
   const handleViewDetails = (project: any) => {
     setCurrentProject(project);
@@ -199,11 +200,13 @@ export default function ProjectManagement() {
           projects={approvedProjects}
           onViewDetails={handleViewDetails}
           onToggleFeature={handleToggleFeature}
+          onReject={handleReject}
           currentPage={currentPage}
           totalPages={totalPages}
           onNextPage={fetchNextPage}
           onPreviousPage={fetchPreviousPage}
         />
+
       );
     }
 
@@ -290,8 +293,12 @@ export default function ProjectManagement() {
           open={rejectDialog}
           onOpenChange={setRejectDialog}
           project={currentProject}
-          onRejected={refreshPending}
+          onRejected={() => {
+            refreshPending();
+            refreshApproved(); 
+          }}
         />
+
       )}
 
       {bulkApproveDialog && selectedProjects.length > 0 && (

--- a/components/tables/ApprovedProjectsTable.tsx
+++ b/components/tables/ApprovedProjectsTable.tsx
@@ -62,7 +62,7 @@ export function ApprovedProjectsTable({
                 <Button size="sm" onClick={() => onViewDetails(project)}>
                   View Details
                 </Button>
-                <Button size="sm" variant="destructive" onClick={() => onReject(project)}>
+                <Button size="sm" variant="destructive" onClick={() => onReject(project)} className='ml-5'>
                   Reject
                 </Button>
               </TableCell>

--- a/components/tables/ApprovedProjectsTable.tsx
+++ b/components/tables/ApprovedProjectsTable.tsx
@@ -12,17 +12,20 @@ interface ApprovedProjectsTableProps {
   totalPages: number;
   onNextPage: () => void;
   onPreviousPage: () => void;
+  onReject: (project: ApprovedProject) => void;
 }
 
 export function ApprovedProjectsTable({
   projects,
   onViewDetails,
   onToggleFeature,
+  onReject,
   currentPage,
   totalPages,
   onNextPage,
   onPreviousPage,
-}: ApprovedProjectsTableProps) {
+}: ApprovedProjectsTableProps)
+ {
   return (
     <div>
       <Table>
@@ -48,16 +51,19 @@ export function ApprovedProjectsTable({
                 />
               </TableCell>
               <TableCell>{project.approvedBy}</TableCell>
-                <TableCell>
-                  {new Date(project.approvedAt).toLocaleDateString('en-GB', {
-                    day: 'numeric',
-                    month: 'long',
-                    year: 'numeric'
-                  })}
-                </TableCell>
+              <TableCell>
+                {new Date(project.approvedAt).toLocaleDateString('en-GB', {
+                  day: 'numeric',
+                  month: 'long',
+                  year: 'numeric'
+                })}
+              </TableCell>
               <TableCell>
                 <Button size="sm" onClick={() => onViewDetails(project)}>
                   View Details
+                </Button>
+                <Button size="sm" variant="destructive" onClick={() => onReject(project)}>
+                  Reject
                 </Button>
               </TableCell>
             </TableRow>


### PR DESCRIPTION
This pull request introduces enhancements to the project management workflow by allowing admins to reject approved projects, updating the UI and API logic accordingly. Key changes include expanding the `handleReject` functionality, modifying the `ApprovedProjectsTable` component, and simplifying the rejection logic in the API route.

### Frontend Changes:
* Updated `handleReject` in `app/(admin)/admin/projects/page.tsx` to support both `PendingProject` and `ApprovedProject` types, enabling rejection of approved projects.
* Added a "Reject" button to the `ApprovedProjectsTable` component, with a new `onReject` prop for handling rejections of approved projects. [[1]](diffhunk://#diff-51940439549adc09030626403779ea5a9f373c9058aa989c3be6373f2f9b6f93R15-R28) [[2]](diffhunk://#diff-51940439549adc09030626403779ea5a9f373c9058aa989c3be6373f2f9b6f93R65-R67)
* Enhanced the rejection dialog to refresh both pending and approved project lists after a rejection.

### Backend Changes:
* Removed logic in `app/api/admin/projects/reject/route.ts` that prevented rejection of already-approved projects, allowing such rejections while still blocking rejections of already-rejected projects.
* Commented out the `approved_by_userId` field update in the rejection API to avoid overwriting approval data.