### PR TITLE
Commited in Improvment/project branch 

### DIFF
--- a/app/(public)/project/page.tsx
+++ b/app/(public)/project/page.tsx
@@ -121,8 +121,12 @@ function ProjectsPageContent() {
                 )}
 
                 {/* Desktop Filter Sidebar */}
-                <div className="sticky top-0 h-screen hidden md:block w-64 lg:w-72 flex-shrink-0">
-                    <FilterSidebar onFilterChange={handleFilterChange} initialFilters={initialFilters} />
+                <div className="hidden md:block w-64 lg:w-72 flex-shrink-0">
+                    <div className="sticky top-0">
+                        <FilterSidebar onFilterChange={handleFilterChange} initialFilters={initialFilters} />
+                    </div>
+        
+                    
                 </div>
 
                 <div className="flex-1">


### PR DESCRIPTION
The filter sidebar currently grows with the page and displays blank space when its content ends. It should scroll with the page until it reaches the top, then remain fixed there while the project list continues to scroll.

Changes:
Wrap <FilterSidebar> in a <div className="sticky top-0">