### PR TITLE
fix(pagination): infinite scroll/page reset fixes for projects and competitions

### DIFF
--- a/app/(public)/competitions/page.tsx
+++ b/app/(public)/competitions/page.tsx
@@ -2,65 +2,71 @@
 // Licensed under the GNU Affero General Public License v3.0 or later,
 // with an additional restriction: Non-commercial use only.
 // See <https://www.gnu.org/licenses/agpl-3.0.html> for details.
-"use client";
+"use client"
 
-import CompetitionCard from "@/components/competition/CompetitionCard";
-import { Button } from "@/components/ui/button";
-import { Dialog, DialogContent, DialogTrigger } from "@/components/ui/dialog";
-import { useApprovedCompetitions } from "@/hooks/competition/useApprovedCompetitions";
-import { ArrowRight, Award, Pen, Play, Target } from "lucide-react";
-import Image from "next/image";
-import Link from "next/link";
-import { useRouter } from "next/navigation";
-import { useCallback, useEffect, useRef, useState } from "react";
+import CompetitionCard from "@/components/competition/CompetitionCard"
+import { Button } from "@/components/ui/button"
+import { Dialog, DialogContent, DialogTrigger } from "@/components/ui/dialog"
+import { useApprovedCompetitions } from "@/hooks/competition/useApprovedCompetitions"
+import { ArrowRight, Award, Pen, Play, Target } from "lucide-react"
+import Image from "next/image"
+import Link from "next/link"
+import { useRouter } from "next/navigation"
+import { useEffect, useRef, useState } from "react"
 
 export default function AwardsPage() {
-  const [videoOpen, setVideoOpen] = useState(false);
-  const router = useRouter();
+  const [videoOpen, setVideoOpen] = useState(false)
+  const router = useRouter()
 
   // Infinite scroll logic
-  const { competitions, isLoading, error, fetchMore, hasMore } =
-    useApprovedCompetitions(9);
-  const loaderRef = useRef<HTMLDivElement | null>(null);
-  const observerRef = useRef<IntersectionObserver | null>(null);
+  const { competitions, isLoading, error, fetchMore, hasMore } = useApprovedCompetitions(9)
+  const loaderRef = useRef<HTMLDivElement | null>(null)
+  const observerRef = useRef<IntersectionObserver | null>(null)
 
-  // Store live values in refs to avoid recreating observer on each state change
-  const fetchMoreRef = useRef(fetchMore);
-  const hasMoreRef = useRef(hasMore);
-  const isLoadingRef = useRef(isLoading);
+  // Use refs to store latest values without triggering observer recreation
+  const fetchMoreRef = useRef(fetchMore)
+  const hasMoreRef = useRef(hasMore)
+  const isLoadingRef = useRef(isLoading)
 
-  // Keep refs in sync with latest values
+  // Keep refs up to date
   useEffect(() => {
-    fetchMoreRef.current = fetchMore;
-    hasMoreRef.current = hasMore;
-    isLoadingRef.current = isLoading;
-  }, [fetchMore, hasMore, isLoading]);
+    fetchMoreRef.current = fetchMore
+  }, [fetchMore])
+
+  useEffect(() => {
+    hasMoreRef.current = hasMore
+  }, [hasMore])
+
+  useEffect(() => {
+    isLoadingRef.current = isLoading
+  }, [isLoading])
 
   const handleClick = () => {
-    router.push("/contact");
-  };
+    router.push("/contact")
+  }
 
-  // Intersection Observer for infinite scroll
-  // Only recreate when competitions.length changes (new page loaded)
+  // Setup intersection observer and recreate only when list length changes
   useEffect(() => {
-    const option = { root: null, rootMargin: "20px", threshold: 0 };
+    if (observerRef.current) observerRef.current.disconnect()
+
+    const option = { root: null, rootMargin: "20px", threshold: 0 }
     observerRef.current = new IntersectionObserver((entries) => {
-      const target = entries[0];
-      if (
-        target.isIntersecting &&
-        hasMoreRef.current &&
-        !isLoadingRef.current
-      ) {
+      const target = entries[0]
+      if (target.isIntersecting && hasMoreRef.current && !isLoadingRef.current) {
         // Immediate in-flight guard to prevent multiple rapid fetchMore calls
-        isLoadingRef.current = true;
-        fetchMoreRef.current();
+        isLoadingRef.current = true
+        fetchMoreRef.current()
       }
-    }, option);
-    if (loaderRef.current) observerRef.current.observe(loaderRef.current);
+    }, option)
+
+    if (loaderRef.current) {
+      observerRef.current.observe(loaderRef.current)
+    }
+
     return () => {
-      if (observerRef.current) observerRef.current.disconnect();
-    };
-  }, [competitions.length]);
+      if (observerRef.current) observerRef.current.disconnect()
+    }
+  }, [competitions.length])
 
   return (
     <div className="min-h-screen bg-#0c0a09">
@@ -73,9 +79,7 @@ export default function AwardsPage() {
               <div className="space-y-4 sm:space-y-6 lg:space-y-8">
                 {/* Badge */}
                 <div className="inline-flex items-center gap-2 rounded-full bg-gray-800 border border-gray-700 px-4 py-2">
-                  <span className="text-sm font-medium text-white">
-                    International & Local Competition
-                  </span>
+                  <span className="text-sm font-medium text-white">International & Local Competition</span>
                 </div>
 
                 {/* Heading */}
@@ -85,11 +89,11 @@ export default function AwardsPage() {
 
                 {/* Description */}
                 <p className="text-base sm:text-lg lg:text-xl text-gray-400 max-w-2xl leading-relaxed">
-                  Discover the innovative teams and groundbreaking projects that
-                  have shaped our competitive landscape through creativity,
-                  technology, and determination.
+                  Discover the innovative teams and groundbreaking projects that have shaped our competitive landscape
+                  through creativity, technology, and determination.
                 </p>
                 <div className="flex flex-wrap  gap-4 sm:gap-6 lg:gap-8">
+
                   <div className="rounded-xl p-6">
                     <div className="mb-4 inline-flex h-12 w-12 items-center justify-center rounded-full border-2 border-primary/30 bg-primary/10 text-primary">
                       <Target className="h-6 w-6" />
@@ -97,9 +101,7 @@ export default function AwardsPage() {
                     <h3 className="text-4xl font-bold tracking-tight text-foreground">
                       50 +
                     </h3>
-                    <p className="mt-2 text-sm text-muted-foreground">
-                      Competitions
-                    </p>
+                    <p className="mt-2 text-sm text-muted-foreground">Competitions</p>
                   </div>
                   <div className="rounded-xl p-6">
                     <div className="mb-4 inline-flex h-12 w-12 items-center justify-center rounded-full border-2 border-primary/30 bg-primary/10 text-primary">
@@ -108,9 +110,7 @@ export default function AwardsPage() {
                     <h3 className="text-4xl font-bold tracking-tight text-foreground">
                       100 +
                     </h3>
-                    <p className="mt-2 text-sm text-muted-foreground">
-                      Competition Winners
-                    </p>
+                    <p className="mt-2 text-sm text-muted-foreground">Competition Winners</p>
                   </div>
                 </div>
               </div>
@@ -121,6 +121,7 @@ export default function AwardsPage() {
               <div className="absolute -inset-4 -z-10 rounded-2xl bg-blue-950/10 blur-sm" />
 
               <div className="grid gap-4 rounded-xl bg-accent/50 p-6 md:gap-6">
+
                 <Image
                   src={"/assets/Dialog.webp"}
                   alt={"Mission 1"}
@@ -130,7 +131,8 @@ export default function AwardsPage() {
                 />
 
                 <div className="grid grid-cols-2 gap-4 md:gap-6">
-                  <div className="overflow-hidden rounded-xl shadow-md transition-transform hover:scale-[1.02]">
+
+                    <div className="overflow-hidden rounded-xl shadow-md transition-transform hover:scale-[1.02]">
                     <Image
                       src={"/assets/1.webp"}
                       alt={"Mission 2"}
@@ -139,9 +141,9 @@ export default function AwardsPage() {
                       className={"rounded-xl object-cover"}
                       style={{ height: "200px", width: "auto" }}
                     />
-                  </div>
+                    </div>
 
-                  <div className="overflow-hidden rounded-xl shadow-md transition-transform hover:scale-[1.02]">
+                    <div className="overflow-hidden rounded-xl shadow-md transition-transform hover:scale-[1.02]">
                     <Image
                       src={"/assets/2.webp"}
                       alt={"Mission 3"}
@@ -150,53 +152,51 @@ export default function AwardsPage() {
                       className={"rounded-xl object-cover"}
                       style={{ height: "200px", width: "auto" }}
                     />
-                  </div>
+                    </div>
+
                 </div>
               </div>
             </div>
           </div>
+
         </div>
       </section>
 
       {/* Competitions Grid */}
       <div className="relative container mx-auto px-4 sm:px-6 lg:px-8 xl:px-12 2xl:px-16 py-12 sm:py-16 lg:py-20">
         <div className="text-center mb-12 sm:mb-16">
-          <h2 className="text-2xl sm:text-3xl lg:text-4xl font-bold text-white mb-4">
-            All Competitions
-          </h2>
-          <p className="text-base text-gray-400">
-            Explore our competitive events and their winners
-          </p>
+          <h2 className="text-2xl sm:text-3xl lg:text-4xl font-bold text-white mb-4">All Competitions</h2>
+          <p className="text-base text-gray-400">Explore our competitive events and their winners</p>
         </div>
         {/* Responsive Grid */}
         <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 gap-6 lg:gap-8">
           {isLoading && competitions.length === 0
             ? Array.from({ length: 6 }).map((_, idx) => (
-                <div
-                  key={idx}
-                  className="animate-pulse rounded-xl border border-gray-700 bg-gray-800 p-6 flex flex-col gap-4 shadow-lg"
-                >
-                  <div className="h-40 bg-gray-700 rounded-md mb-4" />
-                  <div className="h-6 bg-gray-700 rounded w-3/4 mb-2" />
-                  <div className="h-4 bg-gray-700 rounded w-1/2 mb-2" />
-                  <div className="h-4 bg-gray-700 rounded w-1/3" />
-                </div>
-              ))
+              <div
+                key={idx}
+                className="animate-pulse rounded-xl border border-gray-700 bg-gray-800 p-6 flex flex-col gap-4 shadow-lg"
+              >
+                <div className="h-40 bg-gray-700 rounded-md mb-4" />
+                <div className="h-6 bg-gray-700 rounded w-3/4 mb-2" />
+                <div className="h-4 bg-gray-700 rounded w-1/2 mb-2" />
+                <div className="h-4 bg-gray-700 rounded w-1/3" />
+              </div>
+            ))
             : competitions.map((competition) => (
-                <CompetitionCard
-                  key={competition.id}
-                  id={competition.id}
-                  title={competition.name}
-                  cover={competition.cover || "/assets/placeholder.svg"}
-                  type={competition.type || ""}
-                  startDate={competition.startDate}
-                  endDate={competition.endDate}
-                  logo={competition.logo || "/assets/placeholder.svg"}
-                  viewLink={`/competitions/${competition.id}`}
-                  description={competition.description}
-                  winnersCount={competition.winnersCount}
-                />
-              ))}
+              <CompetitionCard
+                key={competition.id}
+                id={competition.id}
+                title={competition.name}
+                cover={competition.cover || "/assets/placeholder.svg"}
+                type={competition.type || ""}
+                startDate={competition.startDate}
+                endDate={competition.endDate}
+                logo={competition.logo || "/assets/placeholder.svg"}
+                viewLink={`/competitions/${competition.id}`}
+                description={competition.description}
+                winnersCount={competition.winnersCount}
+              />
+            ))}
         </div>
         <div ref={loaderRef} className="flex justify-center py-8">
           {isLoading && <span className="text-gray-400">Loading...</span>}
@@ -209,29 +209,30 @@ export default function AwardsPage() {
       <section className="relative m-16 overflow-hidden rounded-2xl bg-gradient-to-br from-accent via-accent/80 to-accent/60 p-8 md:p-12 border border-accent/20 shadow-2xl">
         <div className="mx-auto max-w-4xl text-center relative z-10">
           <h2 className="text-3xl font-bold tracking-tight sm:text-4xl">
-            Want to share your winning project with the community?
+        Want to share your winning project with the community?
           </h2>
           <p className="mt-4 text-lg text-muted-foreground">
-            If you have participated in a competition and won an award, we would
-            love to feature your project. share your achievement with us and
-            inspire others in the community.
-          </p>
+        If you have participated in a competition and won an award, we would love to feature your project.
+        share your achievement with us and inspire others in the community.
+        </p>
           <div className="mt-8 flex flex-wrap justify-center gap-4">
-            <Link href="/submit/competition">
-              <Button size="lg" variant="default">
-                Enter a missing Competition
-              </Button>
-            </Link>
-            <Link href="/submit/award">
-              <Button size="lg" variant="outline">
-                Submit your Award Win
-              </Button>
-            </Link>
+          
+          <Link href="/submit/competition">
+          <Button size="lg" variant="default">
+          
+           Enter a missing Competition
+          </Button>
+        </Link>
+        <Link href="/submit/award">
+          <Button size="lg" variant="outline" >
+           Submit your Award Win
+          </Button>
+        </Link>
           </div>
         </div>
         <div className="pointer-events-none absolute inset-0 bg-gradient-to-r from-blue-500/10 via-purple-500/10 to-pink-500/10 opacity-50" />
         <div className="pointer-events-none absolute inset-0 bg-[linear-gradient(to_right,rgba(255,255,255,0.2)_1px,transparent_1px),linear-gradient(to_bottom,rgba(255,255,255,0.2)_1px,transparent_1px)] bg-[size:40px_40px] [mask-image:linear-gradient(135deg,black_0%,black_20%,transparent_80%,transparent_100%)] opacity-40" />
       </section>
     </div>
-  );
+  )
 }

--- a/app/(public)/competitions/page.tsx
+++ b/app/(public)/competitions/page.tsx
@@ -2,69 +2,65 @@
 // Licensed under the GNU Affero General Public License v3.0 or later,
 // with an additional restriction: Non-commercial use only.
 // See <https://www.gnu.org/licenses/agpl-3.0.html> for details.
-"use client"
+"use client";
 
-import CompetitionCard from "@/components/competition/CompetitionCard"
-import { Button } from "@/components/ui/button"
-import { Dialog, DialogContent, DialogTrigger } from "@/components/ui/dialog"
-import { useApprovedCompetitions } from "@/hooks/competition/useApprovedCompetitions"
-import { ArrowRight, Award, Pen, Play, Target } from "lucide-react"
-import Image from "next/image"
-import Link from "next/link"
-import { useRouter } from "next/navigation"
-import { useEffect, useRef, useState } from "react"
+import CompetitionCard from "@/components/competition/CompetitionCard";
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogTrigger } from "@/components/ui/dialog";
+import { useApprovedCompetitions } from "@/hooks/competition/useApprovedCompetitions";
+import { ArrowRight, Award, Pen, Play, Target } from "lucide-react";
+import Image from "next/image";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 export default function AwardsPage() {
-  const [videoOpen, setVideoOpen] = useState(false)
-  const router = useRouter()
+  const [videoOpen, setVideoOpen] = useState(false);
+  const router = useRouter();
 
   // Infinite scroll logic
-  const { competitions, isLoading, error, fetchMore, hasMore } = useApprovedCompetitions(9)
-  const loaderRef = useRef<HTMLDivElement | null>(null)
-  const observerRef = useRef<IntersectionObserver | null>(null)
+  const { competitions, isLoading, error, fetchMore, hasMore } =
+    useApprovedCompetitions(9);
+  const loaderRef = useRef<HTMLDivElement | null>(null);
+  const observerRef = useRef<IntersectionObserver | null>(null);
 
-  // Use refs to store latest values without triggering observer recreation
-  const fetchMoreRef = useRef(fetchMore)
-  const hasMoreRef = useRef(hasMore)
-  const isLoadingRef = useRef(isLoading)
+  // Store live values in refs to avoid recreating observer on each state change
+  const fetchMoreRef = useRef(fetchMore);
+  const hasMoreRef = useRef(hasMore);
+  const isLoadingRef = useRef(isLoading);
 
-  // Keep refs up to date
+  // Keep refs in sync with latest values
   useEffect(() => {
-    fetchMoreRef.current = fetchMore
-  }, [fetchMore])
-
-  useEffect(() => {
-    hasMoreRef.current = hasMore
-  }, [hasMore])
-
-  useEffect(() => {
-    isLoadingRef.current = isLoading
-  }, [isLoading])
+    fetchMoreRef.current = fetchMore;
+    hasMoreRef.current = hasMore;
+    isLoadingRef.current = isLoading;
+  }, [fetchMore, hasMore, isLoading]);
 
   const handleClick = () => {
-    router.push("/contact")
-  }
+    router.push("/contact");
+  };
 
-  // Setup intersection observer once - uses refs to avoid recreating on every state change
+  // Intersection Observer for infinite scroll
+  // Only recreate when competitions.length changes (new page loaded)
   useEffect(() => {
-    if (observerRef.current) observerRef.current.disconnect()
-
-    const option = { root: null, rootMargin: "20px", threshold: 0 }
+    const option = { root: null, rootMargin: "20px", threshold: 0 };
     observerRef.current = new IntersectionObserver((entries) => {
-      const target = entries[0]
-      if (target.isIntersecting && hasMoreRef.current && !isLoadingRef.current) {
-        fetchMoreRef.current()
+      const target = entries[0];
+      if (
+        target.isIntersecting &&
+        hasMoreRef.current &&
+        !isLoadingRef.current
+      ) {
+        // Immediate in-flight guard to prevent multiple rapid fetchMore calls
+        isLoadingRef.current = true;
+        fetchMoreRef.current();
       }
-    }, option)
-
-    if (loaderRef.current) {
-      observerRef.current.observe(loaderRef.current)
-    }
-
+    }, option);
+    if (loaderRef.current) observerRef.current.observe(loaderRef.current);
     return () => {
-      if (observerRef.current) observerRef.current.disconnect()
-    }
-  }, []) // Empty dependency array - only run once on mount
+      if (observerRef.current) observerRef.current.disconnect();
+    };
+  }, [competitions.length]);
 
   return (
     <div className="min-h-screen bg-#0c0a09">
@@ -77,7 +73,9 @@ export default function AwardsPage() {
               <div className="space-y-4 sm:space-y-6 lg:space-y-8">
                 {/* Badge */}
                 <div className="inline-flex items-center gap-2 rounded-full bg-gray-800 border border-gray-700 px-4 py-2">
-                  <span className="text-sm font-medium text-white">International & Local Competition</span>
+                  <span className="text-sm font-medium text-white">
+                    International & Local Competition
+                  </span>
                 </div>
 
                 {/* Heading */}
@@ -87,11 +85,11 @@ export default function AwardsPage() {
 
                 {/* Description */}
                 <p className="text-base sm:text-lg lg:text-xl text-gray-400 max-w-2xl leading-relaxed">
-                  Discover the innovative teams and groundbreaking projects that have shaped our competitive landscape
-                  through creativity, technology, and determination.
+                  Discover the innovative teams and groundbreaking projects that
+                  have shaped our competitive landscape through creativity,
+                  technology, and determination.
                 </p>
                 <div className="flex flex-wrap  gap-4 sm:gap-6 lg:gap-8">
-
                   <div className="rounded-xl p-6">
                     <div className="mb-4 inline-flex h-12 w-12 items-center justify-center rounded-full border-2 border-primary/30 bg-primary/10 text-primary">
                       <Target className="h-6 w-6" />
@@ -99,7 +97,9 @@ export default function AwardsPage() {
                     <h3 className="text-4xl font-bold tracking-tight text-foreground">
                       50 +
                     </h3>
-                    <p className="mt-2 text-sm text-muted-foreground">Competitions</p>
+                    <p className="mt-2 text-sm text-muted-foreground">
+                      Competitions
+                    </p>
                   </div>
                   <div className="rounded-xl p-6">
                     <div className="mb-4 inline-flex h-12 w-12 items-center justify-center rounded-full border-2 border-primary/30 bg-primary/10 text-primary">
@@ -108,7 +108,9 @@ export default function AwardsPage() {
                     <h3 className="text-4xl font-bold tracking-tight text-foreground">
                       100 +
                     </h3>
-                    <p className="mt-2 text-sm text-muted-foreground">Competition Winners</p>
+                    <p className="mt-2 text-sm text-muted-foreground">
+                      Competition Winners
+                    </p>
                   </div>
                 </div>
               </div>
@@ -119,7 +121,6 @@ export default function AwardsPage() {
               <div className="absolute -inset-4 -z-10 rounded-2xl bg-blue-950/10 blur-sm" />
 
               <div className="grid gap-4 rounded-xl bg-accent/50 p-6 md:gap-6">
-
                 <Image
                   src={"/assets/Dialog.webp"}
                   alt={"Mission 1"}
@@ -129,8 +130,7 @@ export default function AwardsPage() {
                 />
 
                 <div className="grid grid-cols-2 gap-4 md:gap-6">
-
-                    <div className="overflow-hidden rounded-xl shadow-md transition-transform hover:scale-[1.02]">
+                  <div className="overflow-hidden rounded-xl shadow-md transition-transform hover:scale-[1.02]">
                     <Image
                       src={"/assets/1.webp"}
                       alt={"Mission 2"}
@@ -139,9 +139,9 @@ export default function AwardsPage() {
                       className={"rounded-xl object-cover"}
                       style={{ height: "200px", width: "auto" }}
                     />
-                    </div>
+                  </div>
 
-                    <div className="overflow-hidden rounded-xl shadow-md transition-transform hover:scale-[1.02]">
+                  <div className="overflow-hidden rounded-xl shadow-md transition-transform hover:scale-[1.02]">
                     <Image
                       src={"/assets/2.webp"}
                       alt={"Mission 3"}
@@ -150,51 +150,53 @@ export default function AwardsPage() {
                       className={"rounded-xl object-cover"}
                       style={{ height: "200px", width: "auto" }}
                     />
-                    </div>
-
+                  </div>
                 </div>
               </div>
             </div>
           </div>
-
         </div>
       </section>
 
       {/* Competitions Grid */}
       <div className="relative container mx-auto px-4 sm:px-6 lg:px-8 xl:px-12 2xl:px-16 py-12 sm:py-16 lg:py-20">
         <div className="text-center mb-12 sm:mb-16">
-          <h2 className="text-2xl sm:text-3xl lg:text-4xl font-bold text-white mb-4">All Competitions</h2>
-          <p className="text-base text-gray-400">Explore our competitive events and their winners</p>
+          <h2 className="text-2xl sm:text-3xl lg:text-4xl font-bold text-white mb-4">
+            All Competitions
+          </h2>
+          <p className="text-base text-gray-400">
+            Explore our competitive events and their winners
+          </p>
         </div>
         {/* Responsive Grid */}
         <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 gap-6 lg:gap-8">
           {isLoading && competitions.length === 0
             ? Array.from({ length: 6 }).map((_, idx) => (
-              <div
-                key={idx}
-                className="animate-pulse rounded-xl border border-gray-700 bg-gray-800 p-6 flex flex-col gap-4 shadow-lg"
-              >
-                <div className="h-40 bg-gray-700 rounded-md mb-4" />
-                <div className="h-6 bg-gray-700 rounded w-3/4 mb-2" />
-                <div className="h-4 bg-gray-700 rounded w-1/2 mb-2" />
-                <div className="h-4 bg-gray-700 rounded w-1/3" />
-              </div>
-            ))
+                <div
+                  key={idx}
+                  className="animate-pulse rounded-xl border border-gray-700 bg-gray-800 p-6 flex flex-col gap-4 shadow-lg"
+                >
+                  <div className="h-40 bg-gray-700 rounded-md mb-4" />
+                  <div className="h-6 bg-gray-700 rounded w-3/4 mb-2" />
+                  <div className="h-4 bg-gray-700 rounded w-1/2 mb-2" />
+                  <div className="h-4 bg-gray-700 rounded w-1/3" />
+                </div>
+              ))
             : competitions.map((competition) => (
-              <CompetitionCard
-                key={competition.id}
-                id={competition.id}
-                title={competition.name}
-                cover={competition.cover || "/assets/placeholder.svg"}
-                type={competition.type || ""}
-                startDate={competition.startDate}
-                endDate={competition.endDate}
-                logo={competition.logo || "/assets/placeholder.svg"}
-                viewLink={`/competitions/${competition.id}`}
-                description={competition.description}
-                winnersCount={competition.winnersCount}
-              />
-            ))}
+                <CompetitionCard
+                  key={competition.id}
+                  id={competition.id}
+                  title={competition.name}
+                  cover={competition.cover || "/assets/placeholder.svg"}
+                  type={competition.type || ""}
+                  startDate={competition.startDate}
+                  endDate={competition.endDate}
+                  logo={competition.logo || "/assets/placeholder.svg"}
+                  viewLink={`/competitions/${competition.id}`}
+                  description={competition.description}
+                  winnersCount={competition.winnersCount}
+                />
+              ))}
         </div>
         <div ref={loaderRef} className="flex justify-center py-8">
           {isLoading && <span className="text-gray-400">Loading...</span>}
@@ -207,30 +209,29 @@ export default function AwardsPage() {
       <section className="relative m-16 overflow-hidden rounded-2xl bg-gradient-to-br from-accent via-accent/80 to-accent/60 p-8 md:p-12 border border-accent/20 shadow-2xl">
         <div className="mx-auto max-w-4xl text-center relative z-10">
           <h2 className="text-3xl font-bold tracking-tight sm:text-4xl">
-        Want to share your winning project with the community?
+            Want to share your winning project with the community?
           </h2>
           <p className="mt-4 text-lg text-muted-foreground">
-        If you have participated in a competition and won an award, we would love to feature your project.
-        share your achievement with us and inspire others in the community.
-        </p>
+            If you have participated in a competition and won an award, we would
+            love to feature your project. share your achievement with us and
+            inspire others in the community.
+          </p>
           <div className="mt-8 flex flex-wrap justify-center gap-4">
-          
-          <Link href="/submit/competition">
-          <Button size="lg" variant="default">
-          
-           Enter a missing Competition
-          </Button>
-        </Link>
-        <Link href="/submit/award">
-          <Button size="lg" variant="outline" >
-           Submit your Award Win
-          </Button>
-        </Link>
+            <Link href="/submit/competition">
+              <Button size="lg" variant="default">
+                Enter a missing Competition
+              </Button>
+            </Link>
+            <Link href="/submit/award">
+              <Button size="lg" variant="outline">
+                Submit your Award Win
+              </Button>
+            </Link>
           </div>
         </div>
         <div className="pointer-events-none absolute inset-0 bg-gradient-to-r from-blue-500/10 via-purple-500/10 to-pink-500/10 opacity-50" />
         <div className="pointer-events-none absolute inset-0 bg-[linear-gradient(to_right,rgba(255,255,255,0.2)_1px,transparent_1px),linear-gradient(to_bottom,rgba(255,255,255,0.2)_1px,transparent_1px)] bg-[size:40px_40px] [mask-image:linear-gradient(135deg,black_0%,black_20%,transparent_80%,transparent_100%)] opacity-40" />
       </section>
     </div>
-  )
+  );
 }

--- a/app/(public)/competitions/page.tsx
+++ b/app/(public)/competitions/page.tsx
@@ -12,7 +12,7 @@ import { ArrowRight, Award, Pen, Play, Target } from "lucide-react"
 import Image from "next/image"
 import Link from "next/link"
 import { useRouter } from "next/navigation"
-import { useCallback, useEffect, useRef, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 
 export default function AwardsPage() {
   const [videoOpen, setVideoOpen] = useState(false)
@@ -21,25 +21,50 @@ export default function AwardsPage() {
   // Infinite scroll logic
   const { competitions, isLoading, error, fetchMore, hasMore } = useApprovedCompetitions(9)
   const loaderRef = useRef<HTMLDivElement | null>(null)
+  const observerRef = useRef<IntersectionObserver | null>(null)
+
+  // Use refs to store latest values without triggering observer recreation
+  const fetchMoreRef = useRef(fetchMore)
+  const hasMoreRef = useRef(hasMore)
+  const isLoadingRef = useRef(isLoading)
+
+  // Keep refs up to date
+  useEffect(() => {
+    fetchMoreRef.current = fetchMore
+  }, [fetchMore])
+
+  useEffect(() => {
+    hasMoreRef.current = hasMore
+  }, [hasMore])
+
+  useEffect(() => {
+    isLoadingRef.current = isLoading
+  }, [isLoading])
 
   const handleClick = () => {
     router.push("/contact")
   }
 
-  // Intersection Observer for infinite scroll
-  const handleObserver = useCallback((entries: IntersectionObserverEntry[]) => {
-    const target = entries[0]
-    if (target.isIntersecting && hasMore && !isLoading) {
-      fetchMore()
-    }
-  }, [hasMore, isLoading, fetchMore])
-
+  // Setup intersection observer once - uses refs to avoid recreating on every state change
   useEffect(() => {
+    if (observerRef.current) observerRef.current.disconnect()
+
     const option = { root: null, rootMargin: "20px", threshold: 0 }
-    const observer = new window.IntersectionObserver(handleObserver, option)
-    if (loaderRef.current) observer.observe(loaderRef.current)
-    return () => { if (loaderRef.current) observer.unobserve(loaderRef.current) }
-  }, [handleObserver])
+    observerRef.current = new IntersectionObserver((entries) => {
+      const target = entries[0]
+      if (target.isIntersecting && hasMoreRef.current && !isLoadingRef.current) {
+        fetchMoreRef.current()
+      }
+    }, option)
+
+    if (loaderRef.current) {
+      observerRef.current.observe(loaderRef.current)
+    }
+
+    return () => {
+      if (observerRef.current) observerRef.current.disconnect()
+    }
+  }, []) // Empty dependency array - only run once on mount
 
   return (
     <div className="min-h-screen bg-#0c0a09">

--- a/app/(public)/project/page.tsx
+++ b/app/(public)/project/page.tsx
@@ -2,327 +2,292 @@
 // Licensed under the GNU Affero General Public License v3.0 or later,
 // with an additional restriction: Non-commercial use only.
 // See <https://www.gnu.org/licenses/agpl-3.0.html> for details.
-"use client";
+"use client"
 
 import FilterSidebar from "@/components/projects/filter-sidebar";
 import ProjectExplorer from "@/components/projects/project-explorer";
 import SearchHeader from "@/components/projects/search-header";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
-import {
-  ProjectQueryParams,
-  useProjects,
-} from "@/hooks/project/useGetProjects";
+import { ProjectQueryParams, useProjects } from "@/hooks/project/useGetProjects";
 import { X } from "lucide-react";
-import { useRouter, useSearchParams } from "next/navigation";
-import {
-  Suspense,
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-  useRef,
-} from "react";
+import { useRouter, useSearchParams } from 'next/navigation';
+import { Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 interface FilterState {
-  featured: boolean;
-  status: string[];
-  years: string[];
-  projectTypes: string[];
-  domains: string[];
-  sdgGoals: string[];
-  techStack: string[];
+    featured: boolean;
+    status: string[];
+    years: string[];
+    projectTypes: string[];
+    domains: string[];
+    sdgGoals: string[];
+    techStack: string[];
 }
 
 function ProjectsPageContent() {
-  const router = useRouter();
-  const searchParams = useSearchParams();
-  const [showMobileFilters, setShowMobileFilters] = useState(false);
-  const [isInitialLoad, setIsInitialLoad] = useState(true);
+    const router = useRouter();
+    const searchParams = useSearchParams();
+    const [showMobileFilters, setShowMobileFilters] = useState(false);
+    const [isInitialLoad, setIsInitialLoad] = useState(true);
 
-  const currentParams = useMemo(
-    (): ProjectQueryParams => ({
-      page: parseInt(searchParams.get("page") || "1", 10),
-      limit: parseInt(searchParams.get("limit") || "9", 10),
-      title: searchParams.get("title") || undefined,
-      featured: searchParams.get("featured") === "true",
-      status: searchParams.getAll("status"),
-      years: searchParams.getAll("years"),
-      projectTypes: searchParams.getAll("projectTypes"),
-      domains: searchParams.getAll("domains"),
-      sdgGoals: searchParams.getAll("sdgGoals"),
-      techStack: searchParams.getAll("techStack"),
-    }),
-    [searchParams],
-  );
+    const currentParams = useMemo((): ProjectQueryParams => ({
+        page: parseInt(searchParams.get('page') || '1', 10),
+        limit: parseInt(searchParams.get('limit') || '9', 10),
+        title: searchParams.get('title') || undefined,
+        featured: searchParams.get('featured') === 'true',
+        status: searchParams.getAll('status'),
+        years: searchParams.getAll('years'),
+        projectTypes: searchParams.getAll('projectTypes'),
+        domains: searchParams.getAll('domains'),
+        sdgGoals: searchParams.getAll('sdgGoals'),
+        techStack: searchParams.getAll('techStack'),
+    }), [searchParams]);
 
-  // Use the hook with pagination capabilities
-  const { projects, isLoading, error, meta } = useProjects(currentParams);
+    // Use the hook with pagination capabilities
+    const { projects, isLoading, error, meta } = useProjects(currentParams);
 
-  // Set initial load to false after first load completes
-  useEffect(() => {
-    if (!isLoading && projects && isInitialLoad) {
-      setIsInitialLoad(false);
-    }
-  }, [isLoading, projects, isInitialLoad]);
-
-  const initialFilters = useMemo(
-    (): FilterState => ({
-      featured: currentParams.featured || false,
-      status: currentParams.status || [],
-      years: currentParams.years || [],
-      projectTypes: currentParams.projectTypes || [],
-      domains: currentParams.domains || [],
-      sdgGoals: currentParams.sdgGoals || [],
-      techStack: currentParams.techStack || [],
-    }),
-    [currentParams],
-  );
-
-  const toggleFilters = useCallback(() => {
-    setShowMobileFilters((prev) => !prev);
-  }, []);
-
-  // Track the previous filters to avoid unnecessary resets - initialize with current filters
-  const prevFiltersRef = useRef<FilterState>(initialFilters);
-
-  // Keep prevFiltersRef in sync when initialFilters changes from URL
-  useEffect(() => {
-    prevFiltersRef.current = initialFilters;
-  }, [initialFilters]);
-
-  const handleFilterChange = useCallback(
-    (newFilters: FilterState) => {
-      // Check if filters actually changed (not just triggered by re-render)
-      const prev = prevFiltersRef.current;
-      const isSame =
-        prev.featured === newFilters.featured &&
-        JSON.stringify([...prev.status].sort()) ===
-          JSON.stringify([...newFilters.status].sort()) &&
-        JSON.stringify([...prev.years].sort()) ===
-          JSON.stringify([...newFilters.years].sort()) &&
-        JSON.stringify([...prev.projectTypes].sort()) ===
-          JSON.stringify([...newFilters.projectTypes].sort()) &&
-        JSON.stringify([...prev.domains].sort()) ===
-          JSON.stringify([...newFilters.domains].sort()) &&
-        JSON.stringify([...prev.sdgGoals].sort()) ===
-          JSON.stringify([...newFilters.sdgGoals].sort()) &&
-        JSON.stringify([...prev.techStack].sort()) ===
-          JSON.stringify([...newFilters.techStack].sort());
-
-      if (isSame) {
-        // Filters haven't changed, don't reset page
-        return;
-      }
-
-      prevFiltersRef.current = newFilters;
-
-      const params = new URLSearchParams();
-      params.append("page", "1");
-      params.append("limit", String(currentParams.limit || 15));
-      if (currentParams.title) params.append("title", currentParams.title);
-
-      // Handle featured filter
-      if (newFilters.featured) {
-        params.append("featured", "true");
-      }
-
-      // Handle array filters
-      Object.entries(newFilters).forEach(([key, values]) => {
-        // Skip featured as it's already handled above
-        if (key === "featured") return;
-
-        if (Array.isArray(values) && values.length > 0) {
-          values.forEach((value: string) => {
-            params.append(key, value);
-          });
+    // Set initial load to false after first load completes
+    useEffect(() => {
+        if (!isLoading && projects && isInitialLoad) {
+            setIsInitialLoad(false);
         }
-      });
+    }, [isLoading, projects, isInitialLoad]);
 
-      const newUrl = `${window.location.pathname}?${params.toString()}`;
-      router.push(newUrl, { scroll: false });
-    },
-    [router, currentParams.limit, currentParams.title],
-  );
+    const initialFilters = useMemo((): FilterState => ({
+        featured: currentParams.featured || false,
+        status: currentParams.status || [],
+        years: currentParams.years || [],
+        projectTypes: currentParams.projectTypes || [],
+        domains: currentParams.domains || [],
+        sdgGoals: currentParams.sdgGoals || [],
+        techStack: currentParams.techStack || [],
+    }), [currentParams]);
 
-  const handleSearch = useCallback(
-    (value: string) => {
-      const normalizedValue = value.trim();
-      const currentTitle = (searchParams.get("title") || "").trim();
+    const toggleFilters = useCallback(() => {
+        setShowMobileFilters((prev) => !prev);
+    }, []);
 
-      // SearchHeader may re-fire onSearch after page navigation. Only update URL when the query actually changes.
-      if (normalizedValue === currentTitle) {
-        return;
-      }
+    // Track previous filters so unchanged selections do not reset page/push URL
+    const prevFiltersRef = useRef(initialFilters);
 
-      const params = new URLSearchParams(searchParams.toString());
-      if (normalizedValue) {
-        params.set("title", normalizedValue);
-      } else {
-        params.delete("title");
-      }
-      params.set("page", "1");
-      router.push(`${window.location.pathname}?${params.toString()}`, {
-        scroll: false,
-      });
-    },
-    [router, searchParams],
-  );
+    useEffect(() => {
+        prevFiltersRef.current = initialFilters;
+    }, [initialFilters]);
 
-  // Handle mobile filter close with escape key
-  useEffect(() => {
-    const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === "Escape" && showMobileFilters) {
+    const handleFilterChange = useCallback((newFilters: FilterState) => {
+        const prev = prevFiltersRef.current;
+        const isSame =
+            prev.featured === newFilters.featured &&
+            JSON.stringify([...prev.status].sort()) === JSON.stringify([...newFilters.status].sort()) &&
+            JSON.stringify([...prev.years].sort()) === JSON.stringify([...newFilters.years].sort()) &&
+            JSON.stringify([...prev.projectTypes].sort()) === JSON.stringify([...newFilters.projectTypes].sort()) &&
+            JSON.stringify([...prev.domains].sort()) === JSON.stringify([...newFilters.domains].sort()) &&
+            JSON.stringify([...prev.sdgGoals].sort()) === JSON.stringify([...newFilters.sdgGoals].sort()) &&
+            JSON.stringify([...prev.techStack].sort()) === JSON.stringify([...newFilters.techStack].sort());
+
+        if (isSame) {
+            return;
+        }
+
+        prevFiltersRef.current = newFilters;
+
+        const params = new URLSearchParams();
+        params.append('page', '1');
+        params.append('limit', String(currentParams.limit || 15));
+        if (currentParams.title) params.append('title', currentParams.title);
+
+        // Handle featured filter
+        if (newFilters.featured) {
+            params.append('featured', 'true');
+        }
+
+        // Handle array filters
+        Object.entries(newFilters).forEach(([key, values]) => {
+            // Skip featured as it's already handled above
+            if (key === 'featured') return;
+            
+            if (Array.isArray(values) && values.length > 0) {
+                values.forEach((value: string) => {
+                    params.append(key, value);
+                });
+            }
+        });
+
+        const newUrl = `${window.location.pathname}?${params.toString()}`;
+        router.push(newUrl, { scroll: false });
+        
+        // Close mobile filters after applying changes
         //setShowMobileFilters(false);
-      }
-    };
+    }, [router, currentParams.limit, currentParams.title]);
 
-    if (showMobileFilters) {
-      document.addEventListener("keydown", handleEscape);
-      // Prevent body scroll when mobile filters are open
-      document.body.style.overflow = "hidden";
-    } else {
-      document.body.style.overflow = "unset";
+    const handleSearch = useCallback((value: string) => {
+        const normalizedValue = value.trim();
+        const currentTitle = (searchParams.get('title') || '').trim();
+
+        if (normalizedValue === currentTitle) {
+            return;
+        }
+
+        const params = new URLSearchParams(searchParams.toString());
+        if (normalizedValue) {
+            params.set('title', normalizedValue);
+        } else {
+            params.delete('title');
+        }
+        params.set('page', '1');
+        router.push(`${window.location.pathname}?${params.toString()}`, { scroll: false });
+    }, [router, searchParams]);
+
+    // Handle mobile filter close with escape key
+    useEffect(() => {
+        const handleEscape = (e: KeyboardEvent) => {
+            if (e.key === 'Escape' && showMobileFilters) {
+                //setShowMobileFilters(false);
+            }
+        };
+
+        if (showMobileFilters) {
+            document.addEventListener('keydown', handleEscape);
+            // Prevent body scroll when mobile filters are open
+            document.body.style.overflow = 'hidden';
+        } else {
+            document.body.style.overflow = 'unset';
+        }
+
+        return () => {
+            document.removeEventListener('keydown', handleEscape);
+            document.body.style.overflow = 'unset';
+        };
+    }, [showMobileFilters]);
+
+    // Show full page skeleton only on initial load
+    if (isInitialLoad && isLoading && (!projects || projects.length === 0)) {
+        return <LoadingSkeleton />;
     }
 
-    return () => {
-      document.removeEventListener("keydown", handleEscape);
-      document.body.style.overflow = "unset";
-    };
-  }, [showMobileFilters]);
+    return (
+        <div className="relative">
+            <div className="container mx-auto py-8 px-4">
+                <SearchHeader
+                    toggleFilters={toggleFilters}
+                    defaultTitle={currentParams.title ?? ""}
+                    onSearch={handleSearch}
+                />
+                
+                
 
-  // Show full page skeleton only on initial load
-  if (isInitialLoad && isLoading && (!projects || projects.length === 0)) {
-    return <LoadingSkeleton />;
-  }
+                <div className="flex flex-col md:flex-row gap-6 mt-8">
+                    {/* Desktop Filter Sidebar */}
+                    <div className="hidden md:block w-64 lg:w-72 flex-shrink-0">
+                        <div className="sticky top-0">
+                            <FilterSidebar onFilterChange={handleFilterChange} initialFilters={initialFilters} />
+                        </div>
+                    </div>
 
-  return (
-    <div className="relative">
-      <div className="container mx-auto py-8 px-4">
-        <SearchHeader
-          toggleFilters={toggleFilters}
-          defaultTitle={currentParams.title ?? ""}
-          onSearch={handleSearch}
-        />
-
-        <div className="flex flex-col md:flex-row gap-6 mt-8">
-          {/* Desktop Filter Sidebar */}
-          <div className="hidden md:block w-64 lg:w-72 flex-shrink-0">
-            <div className="sticky top-0">
-              <FilterSidebar
-                onFilterChange={handleFilterChange}
-                initialFilters={initialFilters}
-              />
+                    <div className="flex-1">
+                        <ProjectExplorer
+                            currentParams={currentParams}
+                            projects={projects || []}
+                            isLoading={isLoading}
+                            error={error}
+                            meta={meta}
+                            onPageChange={(page) => {
+                                const params = new URLSearchParams(searchParams.toString());
+                                params.set('page', String(page));
+                                router.push(`${window.location.pathname}?${params.toString()}`, {
+                                    scroll: true,
+                                });
+                            }}
+                        />
+                    </div>
+                </div>
             </div>
-          </div>
 
-          <div className="flex-1">
-            <ProjectExplorer
-              currentParams={currentParams}
-              projects={projects || []}
-              isLoading={isLoading}
-              error={error}
-              meta={meta}
-              onPageChange={(page) => {
-                const params = new URLSearchParams(searchParams.toString());
-                params.set("page", String(page));
-                router.push(
-                  `${window.location.pathname}?${params.toString()}`,
-                  {
-                    scroll: true,
-                  },
-                );
-              }}
-            />
-          </div>
+            {/* Mobile Filter Overlay */}
+            {showMobileFilters && (
+                <div 
+                    className="fixed inset-0 bg-black/50 backdrop-blur-sm z-[9999] md:hidden"
+                    style={{ position: 'fixed', top: 0, left: 0, right: 0, bottom: 0 }}
+                >
+                    <div className="fixed inset-0 bg-background flex flex-col">
+                        {/* Header */}
+                        <div className="flex justify-between items-center p-4 border-b bg-background shrink-0">
+                            <h2 className="font-bold text-lg">Filters</h2>
+                            <Button 
+                                variant="ghost" 
+                                size="icon" 
+                                onClick={() => {
+                                    console.log('Close button clicked');
+                                    setShowMobileFilters(false);
+                                }}
+                                className="h-8 w-8 z-[10000]"
+                                type="button"
+                            >
+                                <X className="h-5 w-5" />
+                            </Button>
+                        </div>
+                        
+                        {/* Filter Content - Scrollable */}
+                        <div className="flex-1 overflow-y-auto p-4">
+                            <FilterSidebar 
+                                onFilterChange={handleFilterChange} 
+                                initialFilters={initialFilters} 
+                            />
+                        </div>
+                        
+                        {/* Action buttons */}
+                        <div className="p-4 border-t bg-background shrink-0 flex gap-2">
+                            <Button 
+                                variant="outline" 
+                                className="flex-1"
+                                onClick={() => setShowMobileFilters(false)}
+                                type="button"
+                            >
+                                Cancel
+                            </Button>
+                            <Button 
+                                className="flex-1"
+                                onClick={() => setShowMobileFilters(false)}
+                                type="button"
+                            >
+                                Apply Filters
+                            </Button>
+                        </div>
+                    </div>
+                </div>
+            )}
         </div>
-      </div>
-
-      {/* Mobile Filter Overlay */}
-      {showMobileFilters && (
-        <div
-          className="fixed inset-0 bg-black/50 backdrop-blur-sm z-[9999] md:hidden"
-          style={{ position: "fixed", top: 0, left: 0, right: 0, bottom: 0 }}
-        >
-          <div className="fixed inset-0 bg-background flex flex-col">
-            {/* Header */}
-            <div className="flex justify-between items-center p-4 border-b bg-background shrink-0">
-              <h2 className="font-bold text-lg">Filters</h2>
-              <Button
-                variant="ghost"
-                size="icon"
-                onClick={() => {
-                  console.log("Close button clicked");
-                  setShowMobileFilters(false);
-                }}
-                className="h-8 w-8 z-[10000]"
-                type="button"
-              >
-                <X className="h-5 w-5" />
-              </Button>
-            </div>
-
-            {/* Filter Content - Scrollable */}
-            <div className="flex-1 overflow-y-auto p-4">
-              <FilterSidebar
-                onFilterChange={handleFilterChange}
-                initialFilters={initialFilters}
-              />
-            </div>
-
-            {/* Action buttons */}
-            <div className="p-4 border-t bg-background shrink-0 flex gap-2">
-              <Button
-                variant="outline"
-                className="flex-1"
-                onClick={() => setShowMobileFilters(false)}
-                type="button"
-              >
-                Cancel
-              </Button>
-              <Button
-                className="flex-1"
-                onClick={() => setShowMobileFilters(false)}
-                type="button"
-              >
-                Apply Filters
-              </Button>
-            </div>
-          </div>
-        </div>
-      )}
-    </div>
-  );
+    )
 }
 
 // Wrap the client component in Suspense for loading fallback
 const Page = () => {
-  return (
-    <Suspense fallback={<LoadingSkeleton />}>
-      <ProjectsPageContent />
-    </Suspense>
-  );
+    return (
+        <Suspense fallback={<LoadingSkeleton />}>
+            <ProjectsPageContent />
+        </Suspense>
+    );
 };
 
 // Define a skeleton component for the fallback
 const LoadingSkeleton = () => (
-  <div className="container mx-auto py-8 px-4">
-    <Skeleton className="h-12 w-full mb-8" />
-    <div className="flex flex-col md:flex-row gap-6 mt-8">
-      <div className="hidden md:block w-64 lg:w-72 flex-shrink-0">
-        <Skeleton className="h-64 w-full" />
-      </div>
-      <div className="flex-1">
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          {Array(6)
-            .fill(0)
-            .map((_, i) => (
-              <Skeleton key={i} className="h-[350px] rounded-xl" />
-            ))}
+    <div className="container mx-auto py-8 px-4">
+        <Skeleton className="h-12 w-full mb-8" />
+        <div className="flex flex-col md:flex-row gap-6 mt-8">
+            <div className="hidden md:block w-64 lg:w-72 flex-shrink-0">
+                <Skeleton className="h-64 w-full" />
+            </div>
+            <div className="flex-1">
+                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                    {Array(6)
+                        .fill(0)
+                        .map((_, i) => (
+                            <Skeleton key={i} className="h-[350px] rounded-xl" />
+                        ))}
+                </div>
+            </div>
         </div>
-      </div>
     </div>
-  </div>
 );
 
 export default Page;

--- a/app/(public)/project/page.tsx
+++ b/app/(public)/project/page.tsx
@@ -2,265 +2,327 @@
 // Licensed under the GNU Affero General Public License v3.0 or later,
 // with an additional restriction: Non-commercial use only.
 // See <https://www.gnu.org/licenses/agpl-3.0.html> for details.
-"use client"
+"use client";
 
 import FilterSidebar from "@/components/projects/filter-sidebar";
-import ProjectHeroSection from "@/components/home/ProjectHeroSection";
 import ProjectExplorer from "@/components/projects/project-explorer";
 import SearchHeader from "@/components/projects/search-header";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
-import { ProjectQueryParams, useProjects } from "@/hooks/project/useGetProjects";
+import {
+  ProjectQueryParams,
+  useProjects,
+} from "@/hooks/project/useGetProjects";
 import { X } from "lucide-react";
-import { useRouter, useSearchParams } from 'next/navigation';
-import { Suspense, useCallback, useEffect, useMemo, useState } from 'react';
+import { useRouter, useSearchParams } from "next/navigation";
+import {
+  Suspense,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  useRef,
+} from "react";
 
 interface FilterState {
-    featured: boolean;
-    status: string[];
-    years: string[];
-    projectTypes: string[];
-    domains: string[];
-    sdgGoals: string[];
-    techStack: string[];
+  featured: boolean;
+  status: string[];
+  years: string[];
+  projectTypes: string[];
+  domains: string[];
+  sdgGoals: string[];
+  techStack: string[];
 }
 
 function ProjectsPageContent() {
-    const router = useRouter();
-    const searchParams = useSearchParams();
-    const [showMobileFilters, setShowMobileFilters] = useState(false);
-    const [isInitialLoad, setIsInitialLoad] = useState(true);
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [showMobileFilters, setShowMobileFilters] = useState(false);
+  const [isInitialLoad, setIsInitialLoad] = useState(true);
 
-    const currentParams = useMemo((): ProjectQueryParams => ({
-        page: parseInt(searchParams.get('page') || '1', 10),
-        limit: parseInt(searchParams.get('limit') || '9', 10),
-        title: searchParams.get('title') || undefined,
-        featured: searchParams.get('featured') === 'true',
-        status: searchParams.getAll('status'),
-        years: searchParams.getAll('years'),
-        projectTypes: searchParams.getAll('projectTypes'),
-        domains: searchParams.getAll('domains'),
-        sdgGoals: searchParams.getAll('sdgGoals'),
-        techStack: searchParams.getAll('techStack'),
-    }), [searchParams]);
+  const currentParams = useMemo(
+    (): ProjectQueryParams => ({
+      page: parseInt(searchParams.get("page") || "1", 10),
+      limit: parseInt(searchParams.get("limit") || "9", 10),
+      title: searchParams.get("title") || undefined,
+      featured: searchParams.get("featured") === "true",
+      status: searchParams.getAll("status"),
+      years: searchParams.getAll("years"),
+      projectTypes: searchParams.getAll("projectTypes"),
+      domains: searchParams.getAll("domains"),
+      sdgGoals: searchParams.getAll("sdgGoals"),
+      techStack: searchParams.getAll("techStack"),
+    }),
+    [searchParams],
+  );
 
-    // Use the hook with added infinite scroll capabilities
-    const { projects, isLoading, error, meta, hasMore, loadMore } = useProjects(currentParams);
+  // Use the hook with pagination capabilities
+  const { projects, isLoading, error, meta } = useProjects(currentParams);
 
-    // Set initial load to false after first load completes
-    useEffect(() => {
-        if (!isLoading && projects && isInitialLoad) {
-            setIsInitialLoad(false);
+  // Set initial load to false after first load completes
+  useEffect(() => {
+    if (!isLoading && projects && isInitialLoad) {
+      setIsInitialLoad(false);
+    }
+  }, [isLoading, projects, isInitialLoad]);
+
+  const initialFilters = useMemo(
+    (): FilterState => ({
+      featured: currentParams.featured || false,
+      status: currentParams.status || [],
+      years: currentParams.years || [],
+      projectTypes: currentParams.projectTypes || [],
+      domains: currentParams.domains || [],
+      sdgGoals: currentParams.sdgGoals || [],
+      techStack: currentParams.techStack || [],
+    }),
+    [currentParams],
+  );
+
+  const toggleFilters = useCallback(() => {
+    setShowMobileFilters((prev) => !prev);
+  }, []);
+
+  // Track the previous filters to avoid unnecessary resets - initialize with current filters
+  const prevFiltersRef = useRef<FilterState>(initialFilters);
+
+  // Keep prevFiltersRef in sync when initialFilters changes from URL
+  useEffect(() => {
+    prevFiltersRef.current = initialFilters;
+  }, [initialFilters]);
+
+  const handleFilterChange = useCallback(
+    (newFilters: FilterState) => {
+      // Check if filters actually changed (not just triggered by re-render)
+      const prev = prevFiltersRef.current;
+      const isSame =
+        prev.featured === newFilters.featured &&
+        JSON.stringify([...prev.status].sort()) ===
+          JSON.stringify([...newFilters.status].sort()) &&
+        JSON.stringify([...prev.years].sort()) ===
+          JSON.stringify([...newFilters.years].sort()) &&
+        JSON.stringify([...prev.projectTypes].sort()) ===
+          JSON.stringify([...newFilters.projectTypes].sort()) &&
+        JSON.stringify([...prev.domains].sort()) ===
+          JSON.stringify([...newFilters.domains].sort()) &&
+        JSON.stringify([...prev.sdgGoals].sort()) ===
+          JSON.stringify([...newFilters.sdgGoals].sort()) &&
+        JSON.stringify([...prev.techStack].sort()) ===
+          JSON.stringify([...newFilters.techStack].sort());
+
+      if (isSame) {
+        // Filters haven't changed, don't reset page
+        return;
+      }
+
+      prevFiltersRef.current = newFilters;
+
+      const params = new URLSearchParams();
+      params.append("page", "1");
+      params.append("limit", String(currentParams.limit || 15));
+      if (currentParams.title) params.append("title", currentParams.title);
+
+      // Handle featured filter
+      if (newFilters.featured) {
+        params.append("featured", "true");
+      }
+
+      // Handle array filters
+      Object.entries(newFilters).forEach(([key, values]) => {
+        // Skip featured as it's already handled above
+        if (key === "featured") return;
+
+        if (Array.isArray(values) && values.length > 0) {
+          values.forEach((value: string) => {
+            params.append(key, value);
+          });
         }
-    }, [isLoading, projects, isInitialLoad]);
+      });
 
-    const initialFilters = useMemo((): FilterState => ({
-        featured: currentParams.featured || false,
-        status: currentParams.status || [],
-        years: currentParams.years || [],
-        projectTypes: currentParams.projectTypes || [],
-        domains: currentParams.domains || [],
-        sdgGoals: currentParams.sdgGoals || [],
-        techStack: currentParams.techStack || [],
-    }), [currentParams]);
+      const newUrl = `${window.location.pathname}?${params.toString()}`;
+      router.push(newUrl, { scroll: false });
+    },
+    [router, currentParams.limit, currentParams.title],
+  );
 
-    const toggleFilters = useCallback(() => {
-        console.log('toggleFilters called, current state:', showMobileFilters);
-        setShowMobileFilters(prev => {
-            console.log('Setting showMobileFilters from', prev, 'to', !prev);
-            return !prev;
-        });
-    }, [showMobileFilters]);
+  const handleSearch = useCallback(
+    (value: string) => {
+      const normalizedValue = value.trim();
+      const currentTitle = (searchParams.get("title") || "").trim();
 
-    const handleFilterChange = useCallback((newFilters: FilterState) => {
-        const params = new URLSearchParams();
-        params.append('page', '1');
-        params.append('limit', String(currentParams.limit || 15));
-        if (currentParams.title) params.append('title', currentParams.title);
+      // SearchHeader may re-fire onSearch after page navigation. Only update URL when the query actually changes.
+      if (normalizedValue === currentTitle) {
+        return;
+      }
 
-        // Handle featured filter
-        if (newFilters.featured) {
-            params.append('featured', 'true');
-        }
+      const params = new URLSearchParams(searchParams.toString());
+      if (normalizedValue) {
+        params.set("title", normalizedValue);
+      } else {
+        params.delete("title");
+      }
+      params.set("page", "1");
+      router.push(`${window.location.pathname}?${params.toString()}`, {
+        scroll: false,
+      });
+    },
+    [router, searchParams],
+  );
 
-        // Handle array filters
-        Object.entries(newFilters).forEach(([key, values]) => {
-            // Skip featured as it's already handled above
-            if (key === 'featured') return;
-            
-            if (Array.isArray(values) && values.length > 0) {
-                values.forEach((value: string) => {
-                    params.append(key, value);
-                });
-            }
-        });
-
-        const newUrl = `${window.location.pathname}?${params.toString()}`;
-        router.push(newUrl, { scroll: false });
-        
-        // Close mobile filters after applying changes
+  // Handle mobile filter close with escape key
+  useEffect(() => {
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && showMobileFilters) {
         //setShowMobileFilters(false);
-    }, [router, currentParams.limit, currentParams.title]);
+      }
+    };
 
-    const handleSearch = useCallback((value: string) => {
-        const params = new URLSearchParams(searchParams.toString());
-        if (value) {
-            params.set('title', value);
-        } else {
-            params.delete('title');
-        }
-        params.set('page', '1');
-        router.push(`${window.location.pathname}?${params.toString()}`, { scroll: false });
-    }, [router, searchParams]);
-
-    // Handle mobile filter close with escape key
-    useEffect(() => {
-        const handleEscape = (e: KeyboardEvent) => {
-            if (e.key === 'Escape' && showMobileFilters) {
-                //setShowMobileFilters(false);
-            }
-        };
-
-        if (showMobileFilters) {
-            document.addEventListener('keydown', handleEscape);
-            // Prevent body scroll when mobile filters are open
-            document.body.style.overflow = 'hidden';
-        } else {
-            document.body.style.overflow = 'unset';
-        }
-
-        return () => {
-            document.removeEventListener('keydown', handleEscape);
-            document.body.style.overflow = 'unset';
-        };
-    }, [showMobileFilters]);
-
-    // Show full page skeleton only on initial load
-    if (isInitialLoad && isLoading && (!projects || projects.length === 0)) {
-        return <LoadingSkeleton />;
+    if (showMobileFilters) {
+      document.addEventListener("keydown", handleEscape);
+      // Prevent body scroll when mobile filters are open
+      document.body.style.overflow = "hidden";
+    } else {
+      document.body.style.overflow = "unset";
     }
 
-    console.log('Rendering with showMobileFilters:', showMobileFilters); // Debug log
+    return () => {
+      document.removeEventListener("keydown", handleEscape);
+      document.body.style.overflow = "unset";
+    };
+  }, [showMobileFilters]);
 
-    return (
-        <div className="relative">
-            <ProjectHeroSection />
-            <div className="container mx-auto py-8 px-4">
-                <SearchHeader
-                    toggleFilters={toggleFilters}
-                    defaultTitle={currentParams.title ?? ""}
-                    onSearch={handleSearch}
-                />
-                
-                
+  // Show full page skeleton only on initial load
+  if (isInitialLoad && isLoading && (!projects || projects.length === 0)) {
+    return <LoadingSkeleton />;
+  }
 
-                <div className="flex flex-col md:flex-row gap-6 mt-8">
-                    {/* Desktop Filter Sidebar */}
-                    <div className="hidden md:block w-64 lg:w-72 flex-shrink-0">
-                        <div className="sticky top-0">
-                            <FilterSidebar onFilterChange={handleFilterChange} initialFilters={initialFilters} />
-                        </div>
-                    </div>
+  return (
+    <div className="relative">
+      <div className="container mx-auto py-8 px-4">
+        <SearchHeader
+          toggleFilters={toggleFilters}
+          defaultTitle={currentParams.title ?? ""}
+          onSearch={handleSearch}
+        />
 
-                    <div className="flex-1">
-                        <ProjectExplorer
-                            currentParams={currentParams}
-                            projects={projects || []}
-                            isLoading={isLoading}
-                            error={error}
-                            meta={meta}
-                            hasMore={hasMore}
-                            loadMore={loadMore}
-                        />
-                    </div>
-                </div>
+        <div className="flex flex-col md:flex-row gap-6 mt-8">
+          {/* Desktop Filter Sidebar */}
+          <div className="hidden md:block w-64 lg:w-72 flex-shrink-0">
+            <div className="sticky top-0">
+              <FilterSidebar
+                onFilterChange={handleFilterChange}
+                initialFilters={initialFilters}
+              />
+            </div>
+          </div>
+
+          <div className="flex-1">
+            <ProjectExplorer
+              currentParams={currentParams}
+              projects={projects || []}
+              isLoading={isLoading}
+              error={error}
+              meta={meta}
+              onPageChange={(page) => {
+                const params = new URLSearchParams(searchParams.toString());
+                params.set("page", String(page));
+                router.push(
+                  `${window.location.pathname}?${params.toString()}`,
+                  {
+                    scroll: true,
+                  },
+                );
+              }}
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* Mobile Filter Overlay */}
+      {showMobileFilters && (
+        <div
+          className="fixed inset-0 bg-black/50 backdrop-blur-sm z-[9999] md:hidden"
+          style={{ position: "fixed", top: 0, left: 0, right: 0, bottom: 0 }}
+        >
+          <div className="fixed inset-0 bg-background flex flex-col">
+            {/* Header */}
+            <div className="flex justify-between items-center p-4 border-b bg-background shrink-0">
+              <h2 className="font-bold text-lg">Filters</h2>
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={() => {
+                  console.log("Close button clicked");
+                  setShowMobileFilters(false);
+                }}
+                className="h-8 w-8 z-[10000]"
+                type="button"
+              >
+                <X className="h-5 w-5" />
+              </Button>
             </div>
 
-            {/* Mobile Filter Overlay */}
-            {showMobileFilters && (
-                <div 
-                    className="fixed inset-0 bg-black/50 backdrop-blur-sm z-[9999] md:hidden"
-                    style={{ position: 'fixed', top: 0, left: 0, right: 0, bottom: 0 }}
-                >
-                    <div className="fixed inset-0 bg-background flex flex-col">
-                        {/* Header */}
-                        <div className="flex justify-between items-center p-4 border-b bg-background shrink-0">
-                            <h2 className="font-bold text-lg">Filters</h2>
-                            <Button 
-                                variant="ghost" 
-                                size="icon" 
-                                onClick={() => {
-                                    console.log('Close button clicked');
-                                    setShowMobileFilters(false);
-                                }}
-                                className="h-8 w-8 z-[10000]"
-                                type="button"
-                            >
-                                <X className="h-5 w-5" />
-                            </Button>
-                        </div>
-                        
-                        {/* Filter Content - Scrollable */}
-                        <div className="flex-1 overflow-y-auto p-4">
-                            <FilterSidebar 
-                                onFilterChange={handleFilterChange} 
-                                initialFilters={initialFilters} 
-                            />
-                        </div>
-                        
-                        {/* Action buttons */}
-                        <div className="p-4 border-t bg-background shrink-0 flex gap-2">
-                            <Button 
-                                variant="outline" 
-                                className="flex-1"
-                                onClick={() => setShowMobileFilters(false)}
-                                type="button"
-                            >
-                                Cancel
-                            </Button>
-                            <Button 
-                                className="flex-1"
-                                onClick={() => setShowMobileFilters(false)}
-                                type="button"
-                            >
-                                Apply Filters
-                            </Button>
-                        </div>
-                    </div>
-                </div>
-            )}
+            {/* Filter Content - Scrollable */}
+            <div className="flex-1 overflow-y-auto p-4">
+              <FilterSidebar
+                onFilterChange={handleFilterChange}
+                initialFilters={initialFilters}
+              />
+            </div>
+
+            {/* Action buttons */}
+            <div className="p-4 border-t bg-background shrink-0 flex gap-2">
+              <Button
+                variant="outline"
+                className="flex-1"
+                onClick={() => setShowMobileFilters(false)}
+                type="button"
+              >
+                Cancel
+              </Button>
+              <Button
+                className="flex-1"
+                onClick={() => setShowMobileFilters(false)}
+                type="button"
+              >
+                Apply Filters
+              </Button>
+            </div>
+          </div>
         </div>
-    )
+      )}
+    </div>
+  );
 }
 
 // Wrap the client component in Suspense for loading fallback
 const Page = () => {
-    return (
-        <Suspense fallback={<LoadingSkeleton />}>
-            <ProjectsPageContent />
-        </Suspense>
-    );
+  return (
+    <Suspense fallback={<LoadingSkeleton />}>
+      <ProjectsPageContent />
+    </Suspense>
+  );
 };
 
 // Define a skeleton component for the fallback
 const LoadingSkeleton = () => (
-    <div className="container mx-auto py-8 px-4">
-        <Skeleton className="h-12 w-full mb-8" />
-        <div className="flex flex-col md:flex-row gap-6 mt-8">
-            <div className="hidden md:block w-64 lg:w-72 flex-shrink-0">
-                <Skeleton className="h-64 w-full" />
-            </div>
-            <div className="flex-1">
-                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-                    {Array(6)
-                        .fill(0)
-                        .map((_, i) => (
-                            <Skeleton key={i} className="h-[350px] rounded-xl" />
-                        ))}
-                </div>
-            </div>
+  <div className="container mx-auto py-8 px-4">
+    <Skeleton className="h-12 w-full mb-8" />
+    <div className="flex flex-col md:flex-row gap-6 mt-8">
+      <div className="hidden md:block w-64 lg:w-72 flex-shrink-0">
+        <Skeleton className="h-64 w-full" />
+      </div>
+      <div className="flex-1">
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {Array(6)
+            .fill(0)
+            .map((_, i) => (
+              <Skeleton key={i} className="h-[350px] rounded-xl" />
+            ))}
         </div>
+      </div>
     </div>
+  </div>
 );
 
 export default Page;

--- a/components/projects/filter-sidebar.tsx
+++ b/components/projects/filter-sidebar.tsx
@@ -2,13 +2,23 @@
 // Licensed under the GNU Affero General Public License v3.0 or later,
 // with an additional restriction: Non-commercial use only.
 // See <https://www.gnu.org/licenses/agpl-3.0.html> for details.
-"use client"
+"use client";
 
-import React, { useState, useEffect, useCallback, useMemo } from "react";
-import { Check, ChevronDown, X as ClearIcon, Star } from "lucide-react";
+import React, {
+  useState,
+  useEffect,
+  useCallback,
+  useMemo,
+  useRef,
+} from "react";
+import { ChevronDown, X as ClearIcon } from "lucide-react";
 import { Button } from "../ui/button";
 import { Badge } from "../ui/badge";
-import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "../ui/collapsible";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "../ui/collapsible";
 import { cn } from "@/lib/utils";
 
 import {
@@ -17,7 +27,7 @@ import {
   projectDomainsOptions,
   sdgGoals,
   techStackOptions,
-  yearOptions
+  yearOptions,
 } from "@/lib/types/mapping";
 import { Checkbox } from "../ui/checkbox";
 import { Label } from "../ui/label";
@@ -49,12 +59,12 @@ type FeaturedSectionProps = {
 
 function FeaturedFilterSection({
   selection,
-  setSelection
+  setSelection,
 }: FeaturedSectionProps) {
   const [isOpen, setIsOpen] = useState(true);
 
   const toggleFeatured = useCallback(() => {
-    setSelection(prev => !prev);
+    setSelection((prev) => !prev);
   }, [setSelection]);
 
   return (
@@ -65,7 +75,12 @@ function FeaturedFilterSection({
           className="flex w-full justify-between p-2 font-medium hover:bg-muted/50"
         >
           Featured Projects
-          <ChevronDown className={cn("h-4 w-4 transition-transform", isOpen && "rotate-180")} />
+          <ChevronDown
+            className={cn(
+              "h-4 w-4 transition-transform",
+              isOpen && "rotate-180",
+            )}
+          />
         </Button>
       </CollapsibleTrigger>
       <CollapsibleContent className="px-2 data-[state=open]:animate-collapsible-down data-[state=closed]:animate-collapsible-up overflow-hidden">
@@ -77,8 +92,11 @@ function FeaturedFilterSection({
               onCheckedChange={toggleFeatured}
               className="flex-shrink-0"
             />
-            <Label htmlFor="featured" className="flex-grow truncate text-sm cursor-pointer">
-              Featured 
+            <Label
+              htmlFor="featured"
+              className="flex-grow truncate text-sm cursor-pointer"
+            >
+              Featured
             </Label>
           </div>
         </div>
@@ -103,27 +121,37 @@ function GenericFilterSection({
   options,
   selection,
   setSelection,
-  showIcons = false,
-  showAllOptions = false
+  showAllOptions = false,
 }: GenericSectionProps) {
   const [isOpen, setIsOpen] = useState(true);
   const [showAll, setShowAll] = useState(false);
 
   const initialOptionsCount = 5;
   // If showAllOptions is true, always show all options
-  const displayedOptions = useMemo(() =>
-    showAllOptions ? options : (showAll ? options : options.slice(0, initialOptionsCount)),
-    [options, showAll, initialOptionsCount, showAllOptions]
+  const displayedOptions = useMemo(
+    () =>
+      showAllOptions
+        ? options
+        : showAll
+          ? options
+          : options.slice(0, initialOptionsCount),
+    [options, showAll, initialOptionsCount, showAllOptions],
   );
-  const hasMore = useMemo(() => !showAllOptions && options.length > initialOptionsCount, [options, initialOptionsCount, showAllOptions]);
+  const hasMore = useMemo(
+    () => !showAllOptions && options.length > initialOptionsCount,
+    [options, initialOptionsCount, showAllOptions],
+  );
 
-  const toggleOption = useCallback((value: string) => {
-    setSelection((prev) =>
-      prev.includes(value)
-        ? prev.filter((item) => item !== value)
-        : [...prev, value]
-    );
-  }, [setSelection]);
+  const toggleOption = useCallback(
+    (value: string) => {
+      setSelection((prev) =>
+        prev.includes(value)
+          ? prev.filter((item) => item !== value)
+          : [...prev, value],
+      );
+    },
+    [setSelection],
+  );
 
   return (
     <Collapsible open={isOpen} onOpenChange={setIsOpen} className="w-full">
@@ -133,7 +161,12 @@ function GenericFilterSection({
           className="flex w-full justify-between p-2 font-medium hover:bg-muted/50"
         >
           {title}
-          <ChevronDown className={cn("h-4 w-4 transition-transform", isOpen && "rotate-180")} />
+          <ChevronDown
+            className={cn(
+              "h-4 w-4 transition-transform",
+              isOpen && "rotate-180",
+            )}
+          />
         </Button>
       </CollapsibleTrigger>
       <CollapsibleContent className="px-2 data-[state=open]:animate-collapsible-down data-[state=closed]:animate-collapsible-up overflow-hidden">
@@ -141,14 +174,20 @@ function GenericFilterSection({
           {displayedOptions.map((option) => {
             const isSelected = selection.includes(option.value);
             return (
-              <div key={option.value} className="flex items-center gap-2 px-1 py-1">
+              <div
+                key={option.value}
+                className="flex items-center gap-2 px-1 py-1"
+              >
                 <Checkbox
                   id={option.value}
                   checked={isSelected}
                   onCheckedChange={() => toggleOption(option.value)}
                   className="flex-shrink-0"
                 />
-                <Label htmlFor={option.value} className="flex-grow truncate text-sm cursor-pointer">
+                <Label
+                  htmlFor={option.value}
+                  className="flex-grow truncate text-sm cursor-pointer"
+                >
                   {option.label}
                 </Label>
               </div>
@@ -162,7 +201,9 @@ function GenericFilterSection({
               className="w-full text-xs text-muted-foreground h-auto p-1 mt-1 justify-start"
               onClick={() => setShowAll(!showAll)}
             >
-              {showAll ? "Show less" : `Show ${options.length - initialOptionsCount} more`}
+              {showAll
+                ? "Show less"
+                : `Show ${options.length - initialOptionsCount} more`}
             </Button>
           )}
         </div>
@@ -178,20 +219,22 @@ type TechStackSectionProps = {
   setSelection: React.Dispatch<React.SetStateAction<string[]>>;
 };
 
-function TechStackSection({
-  selection,
-  setSelection
-}: TechStackSectionProps) {
+function TechStackSection({ selection, setSelection }: TechStackSectionProps) {
   const [isOpen, setIsOpen] = useState(true);
-  const [expandedCategories, setExpandedCategories] = useState<Record<string, boolean>>({});
+  const [expandedCategories, setExpandedCategories] = useState<
+    Record<string, boolean>
+  >({});
 
-  const toggleOption = useCallback((value: string) => {
-    setSelection((prev) =>
-      prev.includes(value)
-        ? prev.filter((item) => item !== value)
-        : [...prev, value]
-    );
-  }, [setSelection]);
+  const toggleOption = useCallback(
+    (value: string) => {
+      setSelection((prev) =>
+        prev.includes(value)
+          ? prev.filter((item) => item !== value)
+          : [...prev, value],
+      );
+    },
+    [setSelection],
+  );
 
   // Group tech stack options by type, memoize the result
   const grouped = useMemo(() => {
@@ -200,19 +243,23 @@ function TechStackSection({
       console.error("techStackOptions is not an array:", techStackOptions);
       return {}; // Return empty object if data is invalid
     }
-    return techStackOptions.reduce((acc, tech) => {
-      // Ensure tech object and tech.type are valid
-      if (typeof tech !== 'object' || tech === null) return acc;
-      const typeKey = typeof tech.type === 'string' && tech.type ? tech.type : 'Other';
-      if (!acc[typeKey]) {
-        acc[typeKey] = [];
-      }
-      // Ensure tech.value is valid before pushing
-      if (typeof tech.value === 'string') {
-        acc[typeKey].push(tech);
-      }
-      return acc;
-    }, {} as Record<string, Option[]>); // Type the accumulator
+    return techStackOptions.reduce(
+      (acc, tech) => {
+        // Ensure tech object and tech.type are valid
+        if (typeof tech !== "object" || tech === null) return acc;
+        const typeKey =
+          typeof tech.type === "string" && tech.type ? tech.type : "Other";
+        if (!acc[typeKey]) {
+          acc[typeKey] = [];
+        }
+        // Ensure tech.value is valid before pushing
+        if (typeof tech.value === "string") {
+          acc[typeKey].push(tech);
+        }
+        return acc;
+      },
+      {} as Record<string, Option[]>,
+    ); // Type the accumulator
   }, []); // Dependency array is empty as techStackOptions is imported
 
   const initialOptionsCount = 5;
@@ -225,36 +272,52 @@ function TechStackSection({
           className="flex w-full justify-between p-2 font-medium hover:bg-muted/50"
         >
           Tech Stack
-          <ChevronDown className={cn("h-4 w-4 transition-transform", isOpen && "rotate-180")} />
+          <ChevronDown
+            className={cn(
+              "h-4 w-4 transition-transform",
+              isOpen && "rotate-180",
+            )}
+          />
         </Button>
       </CollapsibleTrigger>
       <CollapsibleContent className="px-2 data-[state=open]:animate-collapsible-down data-[state=closed]:animate-collapsible-up overflow-hidden">
         <div className="pt-1 pb-2 space-y-3">
           {Object.entries(grouped).map(([category, options]) => {
             const isExpanded = expandedCategories[category] ?? false; // Use nullish coalescing
-            const displayed = isExpanded ? options : options.slice(0, initialOptionsCount);
+            const displayed = isExpanded
+              ? options
+              : options.slice(0, initialOptionsCount);
             const hasMore = options.length > initialOptionsCount;
 
             return (
               <div key={category} className="space-y-1">
-                <h4 className="text-xs font-semibold text-muted-foreground px-1 uppercase tracking-wider">{category}</h4>
+                <h4 className="text-xs font-semibold text-muted-foreground px-1 uppercase tracking-wider">
+                  {category}
+                </h4>
                 {displayed.map((option) => {
                   const Icon = option.icon;
                   const isSelected = selection.includes(option.value);
                   return (
-                    <div key={option.value} className="flex items-center gap-2 px-1 py-1">
-                    <Checkbox
-                      id={option.value}
-                      checked={isSelected}
-                      onCheckedChange={() => toggleOption(option.value)}
-                      className="h-4 w-4"
-                    />
-                    {Icon && <Icon className="h-4 w-4 text-muted-foreground flex-shrink-0" />}
-                    <Label htmlFor={option.value} className="flex-grow truncate text-sm cursor-pointer">
-                      {option.label}
-                    </Label>
-                  </div>
-                  
+                    <div
+                      key={option.value}
+                      className="flex items-center gap-2 px-1 py-1"
+                    >
+                      <Checkbox
+                        id={option.value}
+                        checked={isSelected}
+                        onCheckedChange={() => toggleOption(option.value)}
+                        className="h-4 w-4"
+                      />
+                      {Icon && (
+                        <Icon className="h-4 w-4 text-muted-foreground flex-shrink-0" />
+                      )}
+                      <Label
+                        htmlFor={option.value}
+                        className="flex-grow truncate text-sm cursor-pointer"
+                      >
+                        {option.label}
+                      </Label>
+                    </div>
                   );
                 })}
                 {hasMore && (
@@ -265,11 +328,13 @@ function TechStackSection({
                     onClick={() =>
                       setExpandedCategories((prev) => ({
                         ...prev,
-                        [category]: !isExpanded
+                        [category]: !isExpanded,
                       }))
                     }
                   >
-                    {isExpanded ? "Show less" : `Show ${options.length - initialOptionsCount} more`}
+                    {isExpanded
+                      ? "Show less"
+                      : `Show ${options.length - initialOptionsCount} more`}
                   </Button>
                 )}
               </div>
@@ -292,27 +357,48 @@ interface FilterSidebarProps {
 // --- FilterSidebar Component ---
 export default function FilterSidebar({
   onFilterChange,
-  initialFilters
+  initialFilters,
 }: FilterSidebarProps) {
   // Internal state for each filter category, initialized from props
-  const [featuredOnly, setFeaturedOnly] = useState<boolean>(() => initialFilters.featured || false);
-  const [selectedStatuses, setSelectedStatuses] = useState<string[]>(() => initialFilters.status || []);
-  const [selectedYears, setSelectedYears] = useState<string[]>(() => initialFilters.years || []);
-  const [selectedProjectTypes, setSelectedProjectTypes] = useState<string[]>(() => initialFilters.projectTypes || []);
-  const [selectedDomains, setSelectedDomains] = useState<string[]>(() => initialFilters.domains || []);
-  const [selectedSDGs, setSelectedSDGs] = useState<string[]>(() => initialFilters.sdgGoals || []);
-  const [selectedTechStack, setSelectedTechStack] = useState<string[]>(() => initialFilters.techStack || []);
+  const [featuredOnly, setFeaturedOnly] = useState<boolean>(
+    () => initialFilters.featured || false,
+  );
+  const [selectedStatuses, setSelectedStatuses] = useState<string[]>(
+    () => initialFilters.status || [],
+  );
+  const [selectedYears, setSelectedYears] = useState<string[]>(
+    () => initialFilters.years || [],
+  );
+  const [selectedProjectTypes, setSelectedProjectTypes] = useState<string[]>(
+    () => initialFilters.projectTypes || [],
+  );
+  const [selectedDomains, setSelectedDomains] = useState<string[]>(
+    () => initialFilters.domains || [],
+  );
+  const [selectedSDGs, setSelectedSDGs] = useState<string[]>(
+    () => initialFilters.sdgGoals || [],
+  );
+  const [selectedTechStack, setSelectedTechStack] = useState<string[]>(
+    () => initialFilters.techStack || [],
+  );
+
+  // Use a ref for onFilterChange to avoid re-triggering when the parent's
+  // callback identity changes (e.g., on page navigation)
+  const onFilterChangeRef = useRef(onFilterChange);
+  useEffect(() => {
+    onFilterChangeRef.current = onFilterChange;
+  }, [onFilterChange]);
 
   // Memoized callback to notify the parent component of filter changes
   const notifyFilterChange = useCallback(() => {
-    onFilterChange({
+    onFilterChangeRef.current({
       featured: featuredOnly,
       status: selectedStatuses,
       years: selectedYears,
       projectTypes: selectedProjectTypes,
       domains: selectedDomains,
-      sdgGoals: selectedSDGs, // Pass the raw value (e.g., 'GOAL_1')
-      techStack: selectedTechStack
+      sdgGoals: selectedSDGs,
+      techStack: selectedTechStack,
     });
   }, [
     featuredOnly,
@@ -322,19 +408,44 @@ export default function FilterSidebar({
     selectedDomains,
     selectedSDGs,
     selectedTechStack,
-    onFilterChange // Include onFilterChange in dependencies
+    // onFilterChange removed — using ref instead
   ]);
+
+  // Track if this is the initial mount - skip first notification
+  const isInitialMount = useRef(true);
+  // Track the previous initialFilters to detect URL-driven changes
+  const prevInitialFiltersRef = useRef(initialFilters);
 
   // Effect to call the notification callback when any internal filter state changes
   useEffect(() => {
+    // Skip on initial mount
+    if (isInitialMount.current) {
+      isInitialMount.current = false;
+      return;
+    }
+
+    // Skip if initialFilters just changed (URL-driven update, not user interaction)
+    // Compare by checking if all filter arrays are the same as the previous initialFilters
+    const urlJustChanged = prevInitialFiltersRef.current !== initialFilters;
+
+    if (urlJustChanged) {
+      // URL changed, update the ref but don't notify (not a user action)
+      prevInitialFiltersRef.current = initialFilters;
+      return;
+    }
+
     notifyFilterChange();
-  }, [notifyFilterChange]); // Dependency is the memoized callback
+  }, [notifyFilterChange, initialFilters]);
 
   // Effect to update internal state if the initialFilters prop changes (e.g., from URL)
   useEffect(() => {
     // Helper to compare arrays, prevents unnecessary state updates
-    const arraysAreEqual = (a: string[] | undefined, b: string[] | undefined): boolean =>
-      JSON.stringify(a?.sort() || []) === JSON.stringify(b?.sort() || []);
+    const arraysAreEqual = (
+      a: string[] | undefined,
+      b: string[] | undefined,
+    ): boolean =>
+      JSON.stringify([...(a || [])].sort()) ===
+      JSON.stringify([...(b || [])].sort());
 
     if (initialFilters.featured !== featuredOnly) {
       setFeaturedOnly(initialFilters.featured || false);
@@ -364,13 +475,19 @@ export default function FilterSidebar({
   // Map SDG goals for the filter section, memoized
   const sdgOptions: ReadonlyArray<Option> = useMemo(() => {
     // Ensure sdgGoals is an array of objects with a 'name' property
-    if (!Array.isArray(sdgGoals) || !sdgGoals.every(g => typeof g === 'object' && g !== null && typeof g.name === 'string')) {
+    if (
+      !Array.isArray(sdgGoals) ||
+      !sdgGoals.every(
+        (g) =>
+          typeof g === "object" && g !== null && typeof g.name === "string",
+      )
+    ) {
       console.error("Invalid sdgGoals data structure:", sdgGoals);
       return [];
     }
     return sdgGoals.map((goal) => ({
       value: goal.name, // Use the name (e.g., 'GOAL_1') as the value
-      label: goal.name.replace(/_/g, " ").replace(/^GOAL /i, '') // Make label readable (e.g., '1')
+      label: goal.name.replace(/_/g, " ").replace(/^GOAL /i, ""), // Make label readable (e.g., '1')
     }));
   }, []); // Depends on imported sdgGoals
 
@@ -383,9 +500,13 @@ export default function FilterSidebar({
       ...projectTypeOptions,
       ...projectDomainsOptions,
       ...sdgOptions, // Use the mapped sdgOptions
-      ...techStackOptions
-    ].forEach(opt => {
-      if (opt && typeof opt.value === 'string' && typeof opt.label === 'string') {
+      ...techStackOptions,
+    ].forEach((opt) => {
+      if (
+        opt &&
+        typeof opt.value === "string" &&
+        typeof opt.label === "string"
+      ) {
         map.set(opt.value, opt.label);
       }
     });
@@ -395,24 +516,61 @@ export default function FilterSidebar({
   // Create a list of active filters with their labels for display, memoized
   const activeFiltersList = useMemo(() => {
     const filters = [];
-    
+
     // Add featured filter if active
     if (featuredOnly) {
-      filters.push({ type: 'featured' as keyof FilterState, value: 'true', label: 'Featured Only' });
+      filters.push({
+        type: "featured" as keyof FilterState,
+        value: "true",
+        label: "Featured Only",
+      });
     }
-    
+
     // Add other filters
     filters.push(
-      ...selectedStatuses.map(value => ({ type: 'status' as keyof FilterState, value, label: labelMap.get(value) ?? value })),
-      ...selectedYears.map(value => ({ type: 'years' as keyof FilterState, value, label: value })), // Year value is the label
-      ...selectedProjectTypes.map(value => ({ type: 'projectTypes' as keyof FilterState, value, label: labelMap.get(value) ?? value })),
-      ...selectedDomains.map(value => ({ type: 'domains' as keyof FilterState, value, label: labelMap.get(value) ?? value })),
-      ...selectedSDGs.map(value => ({ type: 'sdgGoals' as keyof FilterState, value, label: labelMap.get(value) ?? value })), // Use sdgOptions label
-      ...selectedTechStack.map(value => ({ type: 'techStack' as keyof FilterState, value, label: labelMap.get(value) ?? value })),
+      ...selectedStatuses.map((value) => ({
+        type: "status" as keyof FilterState,
+        value,
+        label: labelMap.get(value) ?? value,
+      })),
+      ...selectedYears.map((value) => ({
+        type: "years" as keyof FilterState,
+        value,
+        label: value,
+      })), // Year value is the label
+      ...selectedProjectTypes.map((value) => ({
+        type: "projectTypes" as keyof FilterState,
+        value,
+        label: labelMap.get(value) ?? value,
+      })),
+      ...selectedDomains.map((value) => ({
+        type: "domains" as keyof FilterState,
+        value,
+        label: labelMap.get(value) ?? value,
+      })),
+      ...selectedSDGs.map((value) => ({
+        type: "sdgGoals" as keyof FilterState,
+        value,
+        label: labelMap.get(value) ?? value,
+      })), // Use sdgOptions label
+      ...selectedTechStack.map((value) => ({
+        type: "techStack" as keyof FilterState,
+        value,
+        label: labelMap.get(value) ?? value,
+      })),
     );
-    
+
     return filters;
-  }, [featuredOnly, selectedStatuses, selectedYears, selectedProjectTypes, selectedDomains, selectedSDGs, selectedTechStack, labelMap]);
+  }, [
+    featuredOnly,
+    selectedStatuses,
+    selectedYears,
+    selectedProjectTypes,
+    selectedDomains,
+    selectedSDGs,
+    selectedTechStack,
+    labelMap,
+  ]);
 
   const hasActiveFilters = activeFiltersList.length > 0;
 
@@ -431,26 +589,30 @@ export default function FilterSidebar({
   }, []);
 
   // Callback to remove a single specific filter internally
-  const removeFilter = useCallback((filterType: keyof FilterState, filterValue: string) => {
-    if (filterType === 'featured') {
-      setFeaturedOnly(false);
-      return;
-    }
+  const removeFilter = useCallback(
+    (filterType: keyof FilterState, filterValue: string) => {
+      if (filterType === "featured") {
+        setFeaturedOnly(false);
+        return;
+      }
 
-    const setterMap = {
-      status: setSelectedStatuses,
-      years: setSelectedYears,
-      projectTypes: setSelectedProjectTypes,
-      domains: setSelectedDomains,
-      sdgGoals: setSelectedSDGs,
-      techStack: setSelectedTechStack,
-    };
-    const setter = setterMap[filterType as Exclude<keyof FilterState, 'featured'>];
-    if (setter) {
-      setter(prev => prev.filter(f => f !== filterValue));
-    }
-    // Parent notification happens via useEffect watching state
-  }, []);
+      const setterMap = {
+        status: setSelectedStatuses,
+        years: setSelectedYears,
+        projectTypes: setSelectedProjectTypes,
+        domains: setSelectedDomains,
+        sdgGoals: setSelectedSDGs,
+        techStack: setSelectedTechStack,
+      };
+      const setter =
+        setterMap[filterType as Exclude<keyof FilterState, "featured">];
+      if (setter) {
+        setter((prev) => prev.filter((f) => f !== filterValue));
+      }
+      // Parent notification happens via useEffect watching state
+    },
+    [],
+  );
 
   // --- JSX Rendering ---
   return (
@@ -459,7 +621,12 @@ export default function FilterSidebar({
       <div className="flex justify-between items-center mb-3 pb-2 border-b">
         <h3 className="font-semibold text-base">Filters</h3>
         {hasActiveFilters && (
-          <Button variant="ghost" size="sm" onClick={clearFilters} className="text-xs h-7 text-muted-foreground hover:text-foreground">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={clearFilters}
+            className="text-xs h-7 text-muted-foreground hover:text-foreground"
+          >
             Clear all
           </Button>
         )}
@@ -469,7 +636,11 @@ export default function FilterSidebar({
       {hasActiveFilters && (
         <div className="flex flex-wrap gap-1 mb-3 flex-shrink-0">
           {activeFiltersList.map((filter) => (
-            <Badge key={`${filter.type}-${filter.value}`} variant="secondary" className="flex items-center gap-1 pr-0.5">
+            <Badge
+              key={`${filter.type}-${filter.value}`}
+              variant="secondary"
+              className="flex items-center gap-1 pr-0.5"
+            >
               <span className="text-xs">{filter.label}</span>
               <Button
                 variant="ghost"

--- a/components/projects/filter-sidebar.tsx
+++ b/components/projects/filter-sidebar.tsx
@@ -2,23 +2,13 @@
 // Licensed under the GNU Affero General Public License v3.0 or later,
 // with an additional restriction: Non-commercial use only.
 // See <https://www.gnu.org/licenses/agpl-3.0.html> for details.
-"use client";
+"use client"
 
-import React, {
-  useState,
-  useEffect,
-  useCallback,
-  useMemo,
-  useRef,
-} from "react";
-import { ChevronDown, X as ClearIcon } from "lucide-react";
+import React, { useState, useEffect, useCallback, useMemo, useRef } from "react";
+import { Check, ChevronDown, X as ClearIcon, Star } from "lucide-react";
 import { Button } from "../ui/button";
 import { Badge } from "../ui/badge";
-import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from "../ui/collapsible";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "../ui/collapsible";
 import { cn } from "@/lib/utils";
 
 import {
@@ -27,7 +17,7 @@ import {
   projectDomainsOptions,
   sdgGoals,
   techStackOptions,
-  yearOptions,
+  yearOptions
 } from "@/lib/types/mapping";
 import { Checkbox } from "../ui/checkbox";
 import { Label } from "../ui/label";
@@ -59,12 +49,12 @@ type FeaturedSectionProps = {
 
 function FeaturedFilterSection({
   selection,
-  setSelection,
+  setSelection
 }: FeaturedSectionProps) {
   const [isOpen, setIsOpen] = useState(true);
 
   const toggleFeatured = useCallback(() => {
-    setSelection((prev) => !prev);
+    setSelection(prev => !prev);
   }, [setSelection]);
 
   return (
@@ -75,12 +65,7 @@ function FeaturedFilterSection({
           className="flex w-full justify-between p-2 font-medium hover:bg-muted/50"
         >
           Featured Projects
-          <ChevronDown
-            className={cn(
-              "h-4 w-4 transition-transform",
-              isOpen && "rotate-180",
-            )}
-          />
+          <ChevronDown className={cn("h-4 w-4 transition-transform", isOpen && "rotate-180")} />
         </Button>
       </CollapsibleTrigger>
       <CollapsibleContent className="px-2 data-[state=open]:animate-collapsible-down data-[state=closed]:animate-collapsible-up overflow-hidden">
@@ -92,11 +77,8 @@ function FeaturedFilterSection({
               onCheckedChange={toggleFeatured}
               className="flex-shrink-0"
             />
-            <Label
-              htmlFor="featured"
-              className="flex-grow truncate text-sm cursor-pointer"
-            >
-              Featured
+            <Label htmlFor="featured" className="flex-grow truncate text-sm cursor-pointer">
+              Featured 
             </Label>
           </div>
         </div>
@@ -121,37 +103,27 @@ function GenericFilterSection({
   options,
   selection,
   setSelection,
-  showAllOptions = false,
+  showIcons = false,
+  showAllOptions = false
 }: GenericSectionProps) {
   const [isOpen, setIsOpen] = useState(true);
   const [showAll, setShowAll] = useState(false);
 
   const initialOptionsCount = 5;
   // If showAllOptions is true, always show all options
-  const displayedOptions = useMemo(
-    () =>
-      showAllOptions
-        ? options
-        : showAll
-          ? options
-          : options.slice(0, initialOptionsCount),
-    [options, showAll, initialOptionsCount, showAllOptions],
+  const displayedOptions = useMemo(() =>
+    showAllOptions ? options : (showAll ? options : options.slice(0, initialOptionsCount)),
+    [options, showAll, initialOptionsCount, showAllOptions]
   );
-  const hasMore = useMemo(
-    () => !showAllOptions && options.length > initialOptionsCount,
-    [options, initialOptionsCount, showAllOptions],
-  );
+  const hasMore = useMemo(() => !showAllOptions && options.length > initialOptionsCount, [options, initialOptionsCount, showAllOptions]);
 
-  const toggleOption = useCallback(
-    (value: string) => {
-      setSelection((prev) =>
-        prev.includes(value)
-          ? prev.filter((item) => item !== value)
-          : [...prev, value],
-      );
-    },
-    [setSelection],
-  );
+  const toggleOption = useCallback((value: string) => {
+    setSelection((prev) =>
+      prev.includes(value)
+        ? prev.filter((item) => item !== value)
+        : [...prev, value]
+    );
+  }, [setSelection]);
 
   return (
     <Collapsible open={isOpen} onOpenChange={setIsOpen} className="w-full">
@@ -161,12 +133,7 @@ function GenericFilterSection({
           className="flex w-full justify-between p-2 font-medium hover:bg-muted/50"
         >
           {title}
-          <ChevronDown
-            className={cn(
-              "h-4 w-4 transition-transform",
-              isOpen && "rotate-180",
-            )}
-          />
+          <ChevronDown className={cn("h-4 w-4 transition-transform", isOpen && "rotate-180")} />
         </Button>
       </CollapsibleTrigger>
       <CollapsibleContent className="px-2 data-[state=open]:animate-collapsible-down data-[state=closed]:animate-collapsible-up overflow-hidden">
@@ -174,20 +141,14 @@ function GenericFilterSection({
           {displayedOptions.map((option) => {
             const isSelected = selection.includes(option.value);
             return (
-              <div
-                key={option.value}
-                className="flex items-center gap-2 px-1 py-1"
-              >
+              <div key={option.value} className="flex items-center gap-2 px-1 py-1">
                 <Checkbox
                   id={option.value}
                   checked={isSelected}
                   onCheckedChange={() => toggleOption(option.value)}
                   className="flex-shrink-0"
                 />
-                <Label
-                  htmlFor={option.value}
-                  className="flex-grow truncate text-sm cursor-pointer"
-                >
+                <Label htmlFor={option.value} className="flex-grow truncate text-sm cursor-pointer">
                   {option.label}
                 </Label>
               </div>
@@ -201,9 +162,7 @@ function GenericFilterSection({
               className="w-full text-xs text-muted-foreground h-auto p-1 mt-1 justify-start"
               onClick={() => setShowAll(!showAll)}
             >
-              {showAll
-                ? "Show less"
-                : `Show ${options.length - initialOptionsCount} more`}
+              {showAll ? "Show less" : `Show ${options.length - initialOptionsCount} more`}
             </Button>
           )}
         </div>
@@ -219,22 +178,20 @@ type TechStackSectionProps = {
   setSelection: React.Dispatch<React.SetStateAction<string[]>>;
 };
 
-function TechStackSection({ selection, setSelection }: TechStackSectionProps) {
+function TechStackSection({
+  selection,
+  setSelection
+}: TechStackSectionProps) {
   const [isOpen, setIsOpen] = useState(true);
-  const [expandedCategories, setExpandedCategories] = useState<
-    Record<string, boolean>
-  >({});
+  const [expandedCategories, setExpandedCategories] = useState<Record<string, boolean>>({});
 
-  const toggleOption = useCallback(
-    (value: string) => {
-      setSelection((prev) =>
-        prev.includes(value)
-          ? prev.filter((item) => item !== value)
-          : [...prev, value],
-      );
-    },
-    [setSelection],
-  );
+  const toggleOption = useCallback((value: string) => {
+    setSelection((prev) =>
+      prev.includes(value)
+        ? prev.filter((item) => item !== value)
+        : [...prev, value]
+    );
+  }, [setSelection]);
 
   // Group tech stack options by type, memoize the result
   const grouped = useMemo(() => {
@@ -243,23 +200,19 @@ function TechStackSection({ selection, setSelection }: TechStackSectionProps) {
       console.error("techStackOptions is not an array:", techStackOptions);
       return {}; // Return empty object if data is invalid
     }
-    return techStackOptions.reduce(
-      (acc, tech) => {
-        // Ensure tech object and tech.type are valid
-        if (typeof tech !== "object" || tech === null) return acc;
-        const typeKey =
-          typeof tech.type === "string" && tech.type ? tech.type : "Other";
-        if (!acc[typeKey]) {
-          acc[typeKey] = [];
-        }
-        // Ensure tech.value is valid before pushing
-        if (typeof tech.value === "string") {
-          acc[typeKey].push(tech);
-        }
-        return acc;
-      },
-      {} as Record<string, Option[]>,
-    ); // Type the accumulator
+    return techStackOptions.reduce((acc, tech) => {
+      // Ensure tech object and tech.type are valid
+      if (typeof tech !== 'object' || tech === null) return acc;
+      const typeKey = typeof tech.type === 'string' && tech.type ? tech.type : 'Other';
+      if (!acc[typeKey]) {
+        acc[typeKey] = [];
+      }
+      // Ensure tech.value is valid before pushing
+      if (typeof tech.value === 'string') {
+        acc[typeKey].push(tech);
+      }
+      return acc;
+    }, {} as Record<string, Option[]>); // Type the accumulator
   }, []); // Dependency array is empty as techStackOptions is imported
 
   const initialOptionsCount = 5;
@@ -272,52 +225,36 @@ function TechStackSection({ selection, setSelection }: TechStackSectionProps) {
           className="flex w-full justify-between p-2 font-medium hover:bg-muted/50"
         >
           Tech Stack
-          <ChevronDown
-            className={cn(
-              "h-4 w-4 transition-transform",
-              isOpen && "rotate-180",
-            )}
-          />
+          <ChevronDown className={cn("h-4 w-4 transition-transform", isOpen && "rotate-180")} />
         </Button>
       </CollapsibleTrigger>
       <CollapsibleContent className="px-2 data-[state=open]:animate-collapsible-down data-[state=closed]:animate-collapsible-up overflow-hidden">
         <div className="pt-1 pb-2 space-y-3">
           {Object.entries(grouped).map(([category, options]) => {
             const isExpanded = expandedCategories[category] ?? false; // Use nullish coalescing
-            const displayed = isExpanded
-              ? options
-              : options.slice(0, initialOptionsCount);
+            const displayed = isExpanded ? options : options.slice(0, initialOptionsCount);
             const hasMore = options.length > initialOptionsCount;
 
             return (
               <div key={category} className="space-y-1">
-                <h4 className="text-xs font-semibold text-muted-foreground px-1 uppercase tracking-wider">
-                  {category}
-                </h4>
+                <h4 className="text-xs font-semibold text-muted-foreground px-1 uppercase tracking-wider">{category}</h4>
                 {displayed.map((option) => {
                   const Icon = option.icon;
                   const isSelected = selection.includes(option.value);
                   return (
-                    <div
-                      key={option.value}
-                      className="flex items-center gap-2 px-1 py-1"
-                    >
-                      <Checkbox
-                        id={option.value}
-                        checked={isSelected}
-                        onCheckedChange={() => toggleOption(option.value)}
-                        className="h-4 w-4"
-                      />
-                      {Icon && (
-                        <Icon className="h-4 w-4 text-muted-foreground flex-shrink-0" />
-                      )}
-                      <Label
-                        htmlFor={option.value}
-                        className="flex-grow truncate text-sm cursor-pointer"
-                      >
-                        {option.label}
-                      </Label>
-                    </div>
+                    <div key={option.value} className="flex items-center gap-2 px-1 py-1">
+                    <Checkbox
+                      id={option.value}
+                      checked={isSelected}
+                      onCheckedChange={() => toggleOption(option.value)}
+                      className="h-4 w-4"
+                    />
+                    {Icon && <Icon className="h-4 w-4 text-muted-foreground flex-shrink-0" />}
+                    <Label htmlFor={option.value} className="flex-grow truncate text-sm cursor-pointer">
+                      {option.label}
+                    </Label>
+                  </div>
+                  
                   );
                 })}
                 {hasMore && (
@@ -328,13 +265,11 @@ function TechStackSection({ selection, setSelection }: TechStackSectionProps) {
                     onClick={() =>
                       setExpandedCategories((prev) => ({
                         ...prev,
-                        [category]: !isExpanded,
+                        [category]: !isExpanded
                       }))
                     }
                   >
-                    {isExpanded
-                      ? "Show less"
-                      : `Show ${options.length - initialOptionsCount} more`}
+                    {isExpanded ? "Show less" : `Show ${options.length - initialOptionsCount} more`}
                   </Button>
                 )}
               </div>
@@ -357,33 +292,18 @@ interface FilterSidebarProps {
 // --- FilterSidebar Component ---
 export default function FilterSidebar({
   onFilterChange,
-  initialFilters,
+  initialFilters
 }: FilterSidebarProps) {
   // Internal state for each filter category, initialized from props
-  const [featuredOnly, setFeaturedOnly] = useState<boolean>(
-    () => initialFilters.featured || false,
-  );
-  const [selectedStatuses, setSelectedStatuses] = useState<string[]>(
-    () => initialFilters.status || [],
-  );
-  const [selectedYears, setSelectedYears] = useState<string[]>(
-    () => initialFilters.years || [],
-  );
-  const [selectedProjectTypes, setSelectedProjectTypes] = useState<string[]>(
-    () => initialFilters.projectTypes || [],
-  );
-  const [selectedDomains, setSelectedDomains] = useState<string[]>(
-    () => initialFilters.domains || [],
-  );
-  const [selectedSDGs, setSelectedSDGs] = useState<string[]>(
-    () => initialFilters.sdgGoals || [],
-  );
-  const [selectedTechStack, setSelectedTechStack] = useState<string[]>(
-    () => initialFilters.techStack || [],
-  );
+  const [featuredOnly, setFeaturedOnly] = useState<boolean>(() => initialFilters.featured || false);
+  const [selectedStatuses, setSelectedStatuses] = useState<string[]>(() => initialFilters.status || []);
+  const [selectedYears, setSelectedYears] = useState<string[]>(() => initialFilters.years || []);
+  const [selectedProjectTypes, setSelectedProjectTypes] = useState<string[]>(() => initialFilters.projectTypes || []);
+  const [selectedDomains, setSelectedDomains] = useState<string[]>(() => initialFilters.domains || []);
+  const [selectedSDGs, setSelectedSDGs] = useState<string[]>(() => initialFilters.sdgGoals || []);
+  const [selectedTechStack, setSelectedTechStack] = useState<string[]>(() => initialFilters.techStack || []);
 
-  // Use a ref for onFilterChange to avoid re-triggering when the parent's
-  // callback identity changes (e.g., on page navigation)
+  // Keep a stable callback reference so parent callback identity changes don't trigger loops.
   const onFilterChangeRef = useRef(onFilterChange);
   useEffect(() => {
     onFilterChangeRef.current = onFilterChange;
@@ -397,8 +317,8 @@ export default function FilterSidebar({
       years: selectedYears,
       projectTypes: selectedProjectTypes,
       domains: selectedDomains,
-      sdgGoals: selectedSDGs,
-      techStack: selectedTechStack,
+      sdgGoals: selectedSDGs, // Pass the raw value (e.g., 'GOAL_1')
+      techStack: selectedTechStack
     });
   }, [
     featuredOnly,
@@ -408,28 +328,21 @@ export default function FilterSidebar({
     selectedDomains,
     selectedSDGs,
     selectedTechStack,
-    // onFilterChange removed — using ref instead
+    // onFilterChange intentionally excluded (tracked via ref)
   ]);
 
-  // Track if this is the initial mount - skip first notification
   const isInitialMount = useRef(true);
-  // Track the previous initialFilters to detect URL-driven changes
   const prevInitialFiltersRef = useRef(initialFilters);
 
   // Effect to call the notification callback when any internal filter state changes
   useEffect(() => {
-    // Skip on initial mount
     if (isInitialMount.current) {
       isInitialMount.current = false;
       return;
     }
 
-    // Skip if initialFilters just changed (URL-driven update, not user interaction)
-    // Compare by checking if all filter arrays are the same as the previous initialFilters
-    const urlJustChanged = prevInitialFiltersRef.current !== initialFilters;
-
+    const urlJustChanged = JSON.stringify(prevInitialFiltersRef.current) !== JSON.stringify(initialFilters);
     if (urlJustChanged) {
-      // URL changed, update the ref but don't notify (not a user action)
       prevInitialFiltersRef.current = initialFilters;
       return;
     }
@@ -440,12 +353,8 @@ export default function FilterSidebar({
   // Effect to update internal state if the initialFilters prop changes (e.g., from URL)
   useEffect(() => {
     // Helper to compare arrays, prevents unnecessary state updates
-    const arraysAreEqual = (
-      a: string[] | undefined,
-      b: string[] | undefined,
-    ): boolean =>
-      JSON.stringify([...(a || [])].sort()) ===
-      JSON.stringify([...(b || [])].sort());
+    const arraysAreEqual = (a: string[] | undefined, b: string[] | undefined): boolean =>
+      JSON.stringify([...(a || [])].sort()) === JSON.stringify([...(b || [])].sort());
 
     if (initialFilters.featured !== featuredOnly) {
       setFeaturedOnly(initialFilters.featured || false);
@@ -468,6 +377,8 @@ export default function FilterSidebar({
     if (!arraysAreEqual(initialFilters.techStack, selectedTechStack)) {
       setSelectedTechStack(initialFilters.techStack || []);
     }
+
+    prevInitialFiltersRef.current = initialFilters;
   }, [initialFilters]); // Depend on the entire initialFilters object
 
   // --- Data Transformations for Display ---
@@ -475,19 +386,13 @@ export default function FilterSidebar({
   // Map SDG goals for the filter section, memoized
   const sdgOptions: ReadonlyArray<Option> = useMemo(() => {
     // Ensure sdgGoals is an array of objects with a 'name' property
-    if (
-      !Array.isArray(sdgGoals) ||
-      !sdgGoals.every(
-        (g) =>
-          typeof g === "object" && g !== null && typeof g.name === "string",
-      )
-    ) {
+    if (!Array.isArray(sdgGoals) || !sdgGoals.every(g => typeof g === 'object' && g !== null && typeof g.name === 'string')) {
       console.error("Invalid sdgGoals data structure:", sdgGoals);
       return [];
     }
     return sdgGoals.map((goal) => ({
       value: goal.name, // Use the name (e.g., 'GOAL_1') as the value
-      label: goal.name.replace(/_/g, " ").replace(/^GOAL /i, ""), // Make label readable (e.g., '1')
+      label: goal.name.replace(/_/g, " ").replace(/^GOAL /i, '') // Make label readable (e.g., '1')
     }));
   }, []); // Depends on imported sdgGoals
 
@@ -500,13 +405,9 @@ export default function FilterSidebar({
       ...projectTypeOptions,
       ...projectDomainsOptions,
       ...sdgOptions, // Use the mapped sdgOptions
-      ...techStackOptions,
-    ].forEach((opt) => {
-      if (
-        opt &&
-        typeof opt.value === "string" &&
-        typeof opt.label === "string"
-      ) {
+      ...techStackOptions
+    ].forEach(opt => {
+      if (opt && typeof opt.value === 'string' && typeof opt.label === 'string') {
         map.set(opt.value, opt.label);
       }
     });
@@ -516,61 +417,24 @@ export default function FilterSidebar({
   // Create a list of active filters with their labels for display, memoized
   const activeFiltersList = useMemo(() => {
     const filters = [];
-
+    
     // Add featured filter if active
     if (featuredOnly) {
-      filters.push({
-        type: "featured" as keyof FilterState,
-        value: "true",
-        label: "Featured Only",
-      });
+      filters.push({ type: 'featured' as keyof FilterState, value: 'true', label: 'Featured Only' });
     }
-
+    
     // Add other filters
     filters.push(
-      ...selectedStatuses.map((value) => ({
-        type: "status" as keyof FilterState,
-        value,
-        label: labelMap.get(value) ?? value,
-      })),
-      ...selectedYears.map((value) => ({
-        type: "years" as keyof FilterState,
-        value,
-        label: value,
-      })), // Year value is the label
-      ...selectedProjectTypes.map((value) => ({
-        type: "projectTypes" as keyof FilterState,
-        value,
-        label: labelMap.get(value) ?? value,
-      })),
-      ...selectedDomains.map((value) => ({
-        type: "domains" as keyof FilterState,
-        value,
-        label: labelMap.get(value) ?? value,
-      })),
-      ...selectedSDGs.map((value) => ({
-        type: "sdgGoals" as keyof FilterState,
-        value,
-        label: labelMap.get(value) ?? value,
-      })), // Use sdgOptions label
-      ...selectedTechStack.map((value) => ({
-        type: "techStack" as keyof FilterState,
-        value,
-        label: labelMap.get(value) ?? value,
-      })),
+      ...selectedStatuses.map(value => ({ type: 'status' as keyof FilterState, value, label: labelMap.get(value) ?? value })),
+      ...selectedYears.map(value => ({ type: 'years' as keyof FilterState, value, label: value })), // Year value is the label
+      ...selectedProjectTypes.map(value => ({ type: 'projectTypes' as keyof FilterState, value, label: labelMap.get(value) ?? value })),
+      ...selectedDomains.map(value => ({ type: 'domains' as keyof FilterState, value, label: labelMap.get(value) ?? value })),
+      ...selectedSDGs.map(value => ({ type: 'sdgGoals' as keyof FilterState, value, label: labelMap.get(value) ?? value })), // Use sdgOptions label
+      ...selectedTechStack.map(value => ({ type: 'techStack' as keyof FilterState, value, label: labelMap.get(value) ?? value })),
     );
-
+    
     return filters;
-  }, [
-    featuredOnly,
-    selectedStatuses,
-    selectedYears,
-    selectedProjectTypes,
-    selectedDomains,
-    selectedSDGs,
-    selectedTechStack,
-    labelMap,
-  ]);
+  }, [featuredOnly, selectedStatuses, selectedYears, selectedProjectTypes, selectedDomains, selectedSDGs, selectedTechStack, labelMap]);
 
   const hasActiveFilters = activeFiltersList.length > 0;
 
@@ -589,30 +453,26 @@ export default function FilterSidebar({
   }, []);
 
   // Callback to remove a single specific filter internally
-  const removeFilter = useCallback(
-    (filterType: keyof FilterState, filterValue: string) => {
-      if (filterType === "featured") {
-        setFeaturedOnly(false);
-        return;
-      }
+  const removeFilter = useCallback((filterType: keyof FilterState, filterValue: string) => {
+    if (filterType === 'featured') {
+      setFeaturedOnly(false);
+      return;
+    }
 
-      const setterMap = {
-        status: setSelectedStatuses,
-        years: setSelectedYears,
-        projectTypes: setSelectedProjectTypes,
-        domains: setSelectedDomains,
-        sdgGoals: setSelectedSDGs,
-        techStack: setSelectedTechStack,
-      };
-      const setter =
-        setterMap[filterType as Exclude<keyof FilterState, "featured">];
-      if (setter) {
-        setter((prev) => prev.filter((f) => f !== filterValue));
-      }
-      // Parent notification happens via useEffect watching state
-    },
-    [],
-  );
+    const setterMap = {
+      status: setSelectedStatuses,
+      years: setSelectedYears,
+      projectTypes: setSelectedProjectTypes,
+      domains: setSelectedDomains,
+      sdgGoals: setSelectedSDGs,
+      techStack: setSelectedTechStack,
+    };
+    const setter = setterMap[filterType as Exclude<keyof FilterState, 'featured'>];
+    if (setter) {
+      setter(prev => prev.filter(f => f !== filterValue));
+    }
+    // Parent notification happens via useEffect watching state
+  }, []);
 
   // --- JSX Rendering ---
   return (
@@ -621,12 +481,7 @@ export default function FilterSidebar({
       <div className="flex justify-between items-center mb-3 pb-2 border-b">
         <h3 className="font-semibold text-base">Filters</h3>
         {hasActiveFilters && (
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={clearFilters}
-            className="text-xs h-7 text-muted-foreground hover:text-foreground"
-          >
+          <Button variant="ghost" size="sm" onClick={clearFilters} className="text-xs h-7 text-muted-foreground hover:text-foreground">
             Clear all
           </Button>
         )}
@@ -636,11 +491,7 @@ export default function FilterSidebar({
       {hasActiveFilters && (
         <div className="flex flex-wrap gap-1 mb-3 flex-shrink-0">
           {activeFiltersList.map((filter) => (
-            <Badge
-              key={`${filter.type}-${filter.value}`}
-              variant="secondary"
-              className="flex items-center gap-1 pr-0.5"
-            >
+            <Badge key={`${filter.type}-${filter.value}`} variant="secondary" className="flex items-center gap-1 pr-0.5">
               <span className="text-xs">{filter.label}</span>
               <Button
                 variant="ghost"

--- a/components/projects/project-explorer.tsx
+++ b/components/projects/project-explorer.tsx
@@ -2,7 +2,9 @@
 // Licensed under the GNU Affero General Public License v3.0 or later,
 // with an additional restriction: Non-commercial use only.
 // See <https://www.gnu.org/licenses/agpl-3.0.html> for details.
+// filepath: d:\MyProjects\LEXi\SDGP-Connect\components\projects\project-explorer.tsx
 "use client";
+
 import Link from "next/link";
 import Image from "next/image";
 import { Skeleton } from "../ui/skeleton";

--- a/components/projects/project-explorer.tsx
+++ b/components/projects/project-explorer.tsx
@@ -5,208 +5,261 @@
 // filepath: d:\MyProjects\LEXi\SDGP-Connect\components\projects\project-explorer.tsx
 import Link from "next/link";
 import Image from "next/image";
-import { Skeleton } from "../ui/skeleton"; 
+import { Skeleton } from "../ui/skeleton";
 import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
 import { ProjectQueryParams } from "@/hooks/project/useGetProjects";
 import { EmptyState } from "../ui/empty-state";
 import { FileX2, ArrowUp } from "lucide-react";
-import { useEffect, useRef, useCallback, useState } from 'react';
+import { useEffect, useRef, useCallback, useState } from "react";
 
 interface ProjectExplorerProps {
-    currentParams: ProjectQueryParams; 
-    projects: any[];
-    isLoading: boolean;
-    error: string | null;
-    meta: any;
-    hasMore: boolean;
-    loadMore: () => void;
+  currentParams: ProjectQueryParams;
+  projects: any[];
+  isLoading: boolean;
+  error: string | null;
+  meta: any;
+  hasMore: boolean;
+  loadMore: () => void;
 }
 
-export default function ProjectExplorer({ currentParams, projects, isLoading, error, meta, hasMore, loadMore }: ProjectExplorerProps) {
-    // Create a ref for the loader element (at bottom of list)
-    const observerRef = useRef<IntersectionObserver | null>(null);
-    const loadingRef = useRef<HTMLDivElement | null>(null);
-    const [showScrollTop, setShowScrollTop] = useState(false);
+export default function ProjectExplorer({
+  currentParams,
+  projects,
+  isLoading,
+  error,
+  meta,
+  hasMore,
+  loadMore,
+}: ProjectExplorerProps) {
+  // Create a ref for the loader element (at bottom of list)
+  const observerRef = useRef<IntersectionObserver | null>(null);
+  const loadingRef = useRef<HTMLDivElement | null>(null);
+  const [showScrollTop, setShowScrollTop] = useState(false);
 
-    // Use refs to store latest values without triggering observer recreation
-    const loadMoreRef = useRef(loadMore);
-    const hasMoreRef = useRef(hasMore);
-    const isLoadingRef = useRef(isLoading);
+  // Use refs to store latest values without triggering observer recreation
+  const loadMoreRef = useRef(loadMore);
+  const hasMoreRef = useRef(hasMore);
+  const isLoadingRef = useRef(isLoading);
 
-    // Keep refs up to date
-    useEffect(() => {
-        loadMoreRef.current = loadMore;
-    }, [loadMore]);
+  // Keep refs up to date
+  useEffect(() => {
+    loadMoreRef.current = loadMore;
+  }, [loadMore]);
 
-    useEffect(() => {
-        hasMoreRef.current = hasMore;
-    }, [hasMore]);
+  useEffect(() => {
+    hasMoreRef.current = hasMore;
+  }, [hasMore]);
 
-    useEffect(() => {
-        isLoadingRef.current = isLoading;
-    }, [isLoading]);
+  useEffect(() => {
+    isLoadingRef.current = isLoading;
+  }, [isLoading]);
 
-    // Setup the intersection observer for infinite scrolling
-    // Only recreate when projects array length changes (new last element)
-    const lastProjectElementRef = useCallback((node: HTMLDivElement) => {
-        // Disconnect any existing observer
-        if (observerRef.current) observerRef.current.disconnect();
+  // Setup the intersection observer for infinite scrolling
+  // Only recreate when projects array length changes (new last element)
+  const lastProjectElementRef = useCallback(
+    (node: HTMLDivElement) => {
+      // Disconnect any existing observer
+      if (observerRef.current) observerRef.current.disconnect();
 
-        if (!node) return;
+      if (!node) return;
 
-        observerRef.current = new IntersectionObserver(entries => {
-            // Only trigger if: in view, has more pages, and not currently loading
-            if (entries[0].isIntersecting && hasMoreRef.current && !isLoadingRef.current) {
-                loadMoreRef.current();
-            }
-        }, { threshold: 0.5 });
+      observerRef.current = new IntersectionObserver(
+        (entries) => {
+          // Only trigger if: in view, has more pages, and not currently loading
+          if (
+            entries[0].isIntersecting &&
+            hasMoreRef.current &&
+            !isLoadingRef.current
+          ) {
+            loadMoreRef.current();
+          }
+        },
+        { threshold: 0.5 },
+      );
 
-        observerRef.current.observe(node);
-    }, [projects.length]); // Only recreate when list length changes
+      observerRef.current.observe(node);
+    },
+    [projects.length],
+  ); // Only recreate when list length changes
 
-    // Add scroll to top button functionality
-    useEffect(() => {
-        const handleScroll = () => {
-            // Show button when user scrolls down 500px
-            setShowScrollTop(window.scrollY > 500);
-        };
-        
-        window.addEventListener('scroll', handleScroll);
-        return () => window.removeEventListener('scroll', handleScroll);
-    }, []);
-
-    const scrollToTop = () => {
-        window.scrollTo({
-            top: 0,
-            behavior: 'smooth'
-        });
+  // Add scroll to top button functionality
+  useEffect(() => {
+    const handleScroll = () => {
+      // Show button when user scrolls down 500px
+      setShowScrollTop(window.scrollY > 500);
     };
 
-    if (error) {
-        return <div className="text-center py-10 text-red-500">Error loading projects: {error}</div>;
-    }
+    window.addEventListener("scroll", handleScroll);
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, []);
 
-    // Initial loading state (when no projects are loaded yet)
-    if (isLoading && (!projects || projects.length === 0)) {
-        return (
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-                {Array(currentParams.limit || 9)
-                    .fill(0)
-                    .map((_, i) => (
-                        <Skeleton key={i} className="h-[350px] rounded-xl bg-muted" />
-                    ))}
-            </div>
-        );
-    }
+  const scrollToTop = () => {
+    window.scrollTo({
+      top: 0,
+      behavior: "smooth",
+    });
+  };
 
-    // Empty state when no projects match filters
-    if (!projects || projects.length === 0) {
-        return (
-            <div className="flex items-center justify-center">
-                <EmptyState title="No projects found" description="Try adjusting your filters or search criteria." icons={[FileX2]} />
-            </div>
-        );
-    }
-
-    // Render projects with infinite scroll
+  if (error) {
     return (
-        <div className="flex flex-col gap-8">
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-                {/* Map through loaded projects */}
-                {projects.map((project, index) => {
-                    // Check if this is the last project
-                    const isLastProject = index === projects.length - 1;
-                    
-                    return (
-                        <div 
-                            key={project.id}
-                            ref={isLastProject ? lastProjectElementRef : null}
-                            className="project-card-container"
-                        >
-                            <Link
-                                href={`/project/${project.id}`}
-                                className="project-card group block rounded-xl overflow-hidden border bg-card shadow-sm hover:shadow-lg transition-all duration-300 ease-in-out"
-                            >
-                                <div className="relative aspect-video overflow-hidden">
-                                    <Image
-                                        src={project.coverImage || "https://placehold.co/600x400?text=NO+IMAGE"}
-                                        alt={project.title || "No title available"}
-                                        fill
-                                        sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
-                                        className="object-cover transition-transform duration-300 group-hover:scale-105"
-                                    />
-                                    {/* Display status badge if status exists */}
-                                    {project.status && (
-                                        <div className="absolute top-2 right-2 z-10">
-                                            <Badge>{project.status}</Badge>
-                                        </div>
-                                    )}
-                                </div>
-
-                                <div className="p-4 flex flex-col h-[calc(100%-aspect-video)]">
-                                    <h3 className="text-lg font-semibold mb-1 line-clamp-1">{project.title}</h3>
-                                    <p className="text-sm text-muted-foreground mb-3 line-clamp-2 flex-grow">
-                                        {project.subtitle || "No subtitle available."}
-                                    </p>
-
-                                    {/* Display Project Types */}
-                                    {(project.projectTypes?.length > 0) && (
-                                        <div className="flex flex-wrap gap-1 mb-3">
-                                            {project.projectTypes.slice(0, 2).map((type: string, i: number) => (
-                                                <Badge key={`${type}-${i}`} variant="outline" className="text-xs">
-                                                    {type}
-                                                </Badge>
-                                            ))}
-                                            {project.projectTypes.length > 2 && (
-                                                <Badge variant="outline" className="text-xs">+{project.projectTypes.length - 2}</Badge>
-                                            )}
-                                        </div>
-                                    )}
-
-                                    {/* Display Domains and View Button */}
-                                    <div className="flex justify-between items-center mt-auto pt-2 border-t border-border/50">
-                                        {(project.domains?.length > 0) ? (
-                                            <div className="flex gap-1 flex-wrap">
-                                                {project.domains.slice(0, 1).map((domain: string, i: number) => (
-                                                    <Badge key={`${domain}-${i}`} variant="secondary" className="text-xs">
-                                                        {domain}
-                                                    </Badge>
-                                                ))}
-                                                {project.domains.length > 1 && (
-                                                    <Badge variant="secondary" className="text-xs">+{project.domains.length - 1}</Badge>
-                                                )}
-                                            </div>
-                                        ) : <div />}
-
-                                        <Button size="sm" variant="ghost" className="text-xs h-7 px-2">
-                                            View Details
-                                        </Button>
-                                    </div>
-                                </div>
-                            </Link>
-                        </div>
-                    );
-                })}
-            </div>
-
-            {/* Loading indicator for infinite scroll */}
-            {isLoading && projects.length > 0 && (
-                <div className="flex justify-center py-4" ref={loadingRef}>
-                    <div className="w-8 h-8 border-2 border-primary/50 border-t-primary rounded-full animate-spin"></div>
-                </div>
-            )}
-
-            {/* Scroll to Top button */}
-            {showScrollTop && (
-                <button 
-                    onClick={scrollToTop} 
-                    className="fixed bottom-4 right-4 p-3 bg-primary text-white rounded-full shadow-md hover:shadow-lg transition-all duration-300 ease-in-out"
-                    aria-label="Scroll to top"
-                >
-                    <ArrowUp className="w-5 h-5 text-black" />
-                </button>
-            )}
-        </div>
+      <div className="text-center py-10 text-red-500">
+        Error loading projects: {error}
+      </div>
     );
+  }
+
+  // Initial loading state (when no projects are loaded yet)
+  if (isLoading && (!projects || projects.length === 0)) {
+    return (
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        {Array(currentParams.limit || 9)
+          .fill(0)
+          .map((_, i) => (
+            <Skeleton key={i} className="h-[350px] rounded-xl bg-muted" />
+          ))}
+      </div>
+    );
+  }
+
+  // Empty state when no projects match filters
+  if (!projects || projects.length === 0) {
+    return (
+      <div className="flex items-center justify-center">
+        <EmptyState
+          title="No projects found"
+          description="Try adjusting your filters or search criteria."
+          icons={[FileX2]}
+        />
+      </div>
+    );
+  }
+
+  // Render projects with infinite scroll
+  return (
+    <div className="flex flex-col gap-8">
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        {/* Map through loaded projects */}
+        {projects.map((project, index) => {
+          // Check if this is the last project
+          const isLastProject = index === projects.length - 1;
+
+          return (
+            <div
+              key={project.id}
+              ref={isLastProject ? lastProjectElementRef : null}
+              className="project-card-container"
+            >
+              <Link
+                href={`/project/${project.id}`}
+                className="project-card group block rounded-xl overflow-hidden border bg-card shadow-sm hover:shadow-lg transition-all duration-300 ease-in-out"
+              >
+                <div className="relative aspect-video overflow-hidden">
+                  <Image
+                    src={
+                      project.coverImage ||
+                      "https://placehold.co/600x400?text=NO+IMAGE"
+                    }
+                    alt={project.title || "No title available"}
+                    fill
+                    sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+                    className="object-cover transition-transform duration-300 group-hover:scale-105"
+                  />
+                  {/* Display status badge if status exists */}
+                  {project.status && (
+                    <div className="absolute top-2 right-2 z-10">
+                      <Badge>{project.status}</Badge>
+                    </div>
+                  )}
+                </div>
+
+                <div className="p-4 flex flex-col h-[calc(100%-aspect-video)]">
+                  <h3 className="text-lg font-semibold mb-1 line-clamp-1">
+                    {project.title}
+                  </h3>
+                  <p className="text-sm text-muted-foreground mb-3 line-clamp-2 flex-grow">
+                    {project.subtitle || "No subtitle available."}
+                  </p>
+
+                  {/* Display Project Types */}
+                  {project.projectTypes?.length > 0 && (
+                    <div className="flex flex-wrap gap-1 mb-3">
+                      {project.projectTypes
+                        .slice(0, 2)
+                        .map((type: string, i: number) => (
+                          <Badge
+                            key={`${type}-${i}`}
+                            variant="outline"
+                            className="text-xs"
+                          >
+                            {type}
+                          </Badge>
+                        ))}
+                      {project.projectTypes.length > 2 && (
+                        <Badge variant="outline" className="text-xs">
+                          +{project.projectTypes.length - 2}
+                        </Badge>
+                      )}
+                    </div>
+                  )}
+
+                  {/* Display Domains and View Button */}
+                  <div className="flex justify-between items-center mt-auto pt-2 border-t border-border/50">
+                    {project.domains?.length > 0 ? (
+                      <div className="flex gap-1 flex-wrap">
+                        {project.domains
+                          .slice(0, 1)
+                          .map((domain: string, i: number) => (
+                            <Badge
+                              key={`${domain}-${i}`}
+                              variant="secondary"
+                              className="text-xs"
+                            >
+                              {domain}
+                            </Badge>
+                          ))}
+                        {project.domains.length > 1 && (
+                          <Badge variant="secondary" className="text-xs">
+                            +{project.domains.length - 1}
+                          </Badge>
+                        )}
+                      </div>
+                    ) : (
+                      <div />
+                    )}
+
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      className="text-xs h-7 px-2"
+                    >
+                      View Details
+                    </Button>
+                  </div>
+                </div>
+              </Link>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Loading indicator for infinite scroll */}
+      {isLoading && projects.length > 0 && (
+        <div className="flex justify-center py-4" ref={loadingRef}>
+          <div className="w-8 h-8 border-2 border-primary/50 border-t-primary rounded-full animate-spin"></div>
+        </div>
+      )}
+
+      {/* Scroll to Top button */}
+      {showScrollTop && (
+        <button
+          onClick={scrollToTop}
+          className="fixed bottom-4 right-4 p-3 bg-primary text-white rounded-full shadow-md hover:shadow-lg transition-all duration-300 ease-in-out"
+          aria-label="Scroll to top"
+        >
+          <ArrowUp className="w-5 h-5 text-black" />
+        </button>
+      )}
+    </div>
+  );
 }

--- a/components/projects/project-explorer.tsx
+++ b/components/projects/project-explorer.tsx
@@ -2,7 +2,7 @@
 // Licensed under the GNU Affero General Public License v3.0 or later,
 // with an additional restriction: Non-commercial use only.
 // See <https://www.gnu.org/licenses/agpl-3.0.html> for details.
-// filepath: d:\MyProjects\LEXi\SDGP-Connect\components\projects\project-explorer.tsx
+"use client";
 import Link from "next/link";
 import Image from "next/image";
 import { Skeleton } from "../ui/skeleton";
@@ -10,17 +10,17 @@ import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
 import { ProjectQueryParams } from "@/hooks/project/useGetProjects";
 import { EmptyState } from "../ui/empty-state";
-import { FileX2, ArrowUp } from "lucide-react";
-import { useEffect, useRef, useCallback, useState } from "react";
+import { FileX2, ChevronLeft, ChevronRight } from "lucide-react";
+import { PaginatedResponse } from "@/types/project/pagination";
+import { ProjectCardType } from "@/types/project/card";
 
 interface ProjectExplorerProps {
   currentParams: ProjectQueryParams;
   projects: any[];
   isLoading: boolean;
   error: string | null;
-  meta: any;
-  hasMore: boolean;
-  loadMore: () => void;
+  meta: PaginatedResponse<ProjectCardType>["meta"] | null;
+  onPageChange: (page: number) => void;
 }
 
 export default function ProjectExplorer({
@@ -29,78 +29,8 @@ export default function ProjectExplorer({
   isLoading,
   error,
   meta,
-  hasMore,
-  loadMore,
+  onPageChange,
 }: ProjectExplorerProps) {
-  // Create a ref for the loader element (at bottom of list)
-  const observerRef = useRef<IntersectionObserver | null>(null);
-  const loadingRef = useRef<HTMLDivElement | null>(null);
-  const [showScrollTop, setShowScrollTop] = useState(false);
-
-  // Use refs to store latest values without triggering observer recreation
-  const loadMoreRef = useRef(loadMore);
-  const hasMoreRef = useRef(hasMore);
-  const isLoadingRef = useRef(isLoading);
-
-  // Keep refs up to date
-  useEffect(() => {
-    loadMoreRef.current = loadMore;
-  }, [loadMore]);
-
-  useEffect(() => {
-    hasMoreRef.current = hasMore;
-  }, [hasMore]);
-
-  useEffect(() => {
-    isLoadingRef.current = isLoading;
-  }, [isLoading]);
-
-  // Setup the intersection observer for infinite scrolling
-  // Only recreate when projects array length changes (new last element)
-  const lastProjectElementRef = useCallback(
-    (node: HTMLDivElement) => {
-      // Disconnect any existing observer
-      if (observerRef.current) observerRef.current.disconnect();
-
-      if (!node) return;
-
-      observerRef.current = new IntersectionObserver(
-        (entries) => {
-          // Only trigger if: in view, has more pages, and not currently loading
-          if (
-            entries[0].isIntersecting &&
-            hasMoreRef.current &&
-            !isLoadingRef.current
-          ) {
-            loadMoreRef.current();
-          }
-        },
-        { threshold: 0.5 },
-      );
-
-      observerRef.current.observe(node);
-    },
-    [projects.length],
-  ); // Only recreate when list length changes
-
-  // Add scroll to top button functionality
-  useEffect(() => {
-    const handleScroll = () => {
-      // Show button when user scrolls down 500px
-      setShowScrollTop(window.scrollY > 500);
-    };
-
-    window.addEventListener("scroll", handleScroll);
-    return () => window.removeEventListener("scroll", handleScroll);
-  }, []);
-
-  const scrollToTop = () => {
-    window.scrollTo({
-      top: 0,
-      behavior: "smooth",
-    });
-  };
-
   if (error) {
     return (
       <div className="text-center py-10 text-red-500">
@@ -135,21 +65,19 @@ export default function ProjectExplorer({
     );
   }
 
-  // Render projects with infinite scroll
+  const currentPage = meta?.currentPage || 1;
+  const totalPages = meta?.totalPages || 1;
+  const hasNextPage = meta?.hasNextPage ?? currentPage < totalPages;
+  const hasPrevPage = meta?.hasPrevPage ?? currentPage > 1;
+
+  // Render projects with pagination controls
   return (
     <div className="flex flex-col gap-8">
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
         {/* Map through loaded projects */}
-        {projects.map((project, index) => {
-          // Check if this is the last project
-          const isLastProject = index === projects.length - 1;
-
+        {projects.map((project) => {
           return (
-            <div
-              key={project.id}
-              ref={isLastProject ? lastProjectElementRef : null}
-              className="project-card-container"
-            >
+            <div key={project.id} className="project-card-container">
               <Link
                 href={`/project/${project.id}`}
                 className="project-card group block rounded-xl overflow-hidden border bg-card shadow-sm hover:shadow-lg transition-all duration-300 ease-in-out"
@@ -243,22 +171,42 @@ export default function ProjectExplorer({
         })}
       </div>
 
-      {/* Loading indicator for infinite scroll */}
+      {/* Loading overlay for page transitions */}
       {isLoading && projects.length > 0 && (
-        <div className="flex justify-center py-4" ref={loadingRef}>
+        <div className="flex justify-center py-4">
           <div className="w-8 h-8 border-2 border-primary/50 border-t-primary rounded-full animate-spin"></div>
         </div>
       )}
 
-      {/* Scroll to Top button */}
-      {showScrollTop && (
-        <button
-          onClick={scrollToTop}
-          className="fixed bottom-4 right-4 p-3 bg-primary text-white rounded-full shadow-md hover:shadow-lg transition-all duration-300 ease-in-out"
-          aria-label="Scroll to top"
-        >
-          <ArrowUp className="w-5 h-5 text-black" />
-        </button>
+      {/* Pagination Controls */}
+      {totalPages > 1 && (
+        <div className="flex items-center justify-center gap-4 py-4">
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={!hasPrevPage || isLoading}
+            onClick={() => onPageChange(currentPage - 1)}
+            className="flex items-center gap-1"
+          >
+            <ChevronLeft className="w-4 h-4" />
+            Previous
+          </Button>
+
+          <span className="text-sm text-muted-foreground">
+            Page {currentPage} of {totalPages}
+          </span>
+
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={!hasNextPage || isLoading}
+            onClick={() => onPageChange(currentPage + 1)}
+            className="flex items-center gap-1"
+          >
+            Next
+            <ChevronRight className="w-4 h-4" />
+          </Button>
+        </div>
       )}
     </div>
   );

--- a/components/projects/project-explorer.tsx
+++ b/components/projects/project-explorer.tsx
@@ -29,20 +29,41 @@ export default function ProjectExplorer({ currentParams, projects, isLoading, er
     const loadingRef = useRef<HTMLDivElement | null>(null);
     const [showScrollTop, setShowScrollTop] = useState(false);
 
+    // Use refs to store latest values without triggering observer recreation
+    const loadMoreRef = useRef(loadMore);
+    const hasMoreRef = useRef(hasMore);
+    const isLoadingRef = useRef(isLoading);
+
+    // Keep refs up to date
+    useEffect(() => {
+        loadMoreRef.current = loadMore;
+    }, [loadMore]);
+
+    useEffect(() => {
+        hasMoreRef.current = hasMore;
+    }, [hasMore]);
+
+    useEffect(() => {
+        isLoadingRef.current = isLoading;
+    }, [isLoading]);
+
     // Setup the intersection observer for infinite scrolling
+    // Only recreate when projects array length changes (new last element)
     const lastProjectElementRef = useCallback((node: HTMLDivElement) => {
-        if (isLoading) return;
-        
+        // Disconnect any existing observer
         if (observerRef.current) observerRef.current.disconnect();
-        
+
+        if (!node) return;
+
         observerRef.current = new IntersectionObserver(entries => {
-            if (entries[0].isIntersecting && hasMore) {
-                loadMore();
+            // Only trigger if: in view, has more pages, and not currently loading
+            if (entries[0].isIntersecting && hasMoreRef.current && !isLoadingRef.current) {
+                loadMoreRef.current();
             }
         }, { threshold: 0.5 });
-        
-        if (node) observerRef.current.observe(node);
-    }, [isLoading, hasMore, loadMore]);
+
+        observerRef.current.observe(node);
+    }, [projects.length]); // Only recreate when list length changes
 
     // Add scroll to top button functionality
     useEffect(() => {

--- a/hooks/project/useGetProjects.ts
+++ b/hooks/project/useGetProjects.ts
@@ -15,7 +15,6 @@ function useProjects(currentParams: ProjectQueryParams) {
     PaginatedResponse<ProjectCardType>["meta"] | null
   >(null);
 
-  // Fetch projects for the given page (always replaces, never appends)
   const fetchProjects = useCallback(
     async (page: number) => {
       setIsLoading(true);
@@ -123,6 +122,7 @@ function useProjects(currentParams: ProjectQueryParams) {
         }
 
         setProjects(projectsData);
+
         setMeta(metaData);
       } catch (err) {
         setError(

--- a/hooks/project/useGetProjects.ts
+++ b/hooks/project/useGetProjects.ts
@@ -14,11 +14,10 @@ function useProjects(currentParams: ProjectQueryParams) {
   const [meta, setMeta] = useState<
     PaginatedResponse<ProjectCardType>["meta"] | null
   >(null);
-  const [hasMore, setHasMore] = useState(true);
-  const [currentPage, setCurrentPage] = useState(1);
 
+  // Fetch projects for the given page (always replaces, never appends)
   const fetchProjects = useCallback(
-    async (page: number, shouldAppend: boolean = false) => {
+    async (page: number) => {
       setIsLoading(true);
       setError(null);
 
@@ -123,25 +122,8 @@ function useProjects(currentParams: ProjectQueryParams) {
           metaData = paginatedResult.meta;
         }
 
-        // For infinite scroll: append new projects instead of replacing them
-        // But for featured projects, we typically don't use infinite scroll
-        if (shouldAppend && !currentParams.featured) {
-          setProjects((prev) => [...prev, ...projectsData]);
-        } else {
-          setProjects(projectsData);
-        }
-
+        setProjects(projectsData);
         setMeta(metaData);
-
-        // Update hasMore based on pagination metadata
-        // Featured projects don't have pagination, so hasMore should be false
-        if (currentParams.featured) {
-          setHasMore(false);
-        } else {
-          setHasMore(page < metaData.totalPages);
-        }
-
-        setCurrentPage(page);
       } catch (err) {
         setError(
           err instanceof Error
@@ -149,9 +131,7 @@ function useProjects(currentParams: ProjectQueryParams) {
             : "An error occurred while fetching projects",
         );
         console.error("Error fetching projects:", err);
-        if (!shouldAppend) {
-          setProjects([]);
-        }
+        setProjects([]);
       } finally {
         setIsLoading(false);
       }
@@ -159,15 +139,12 @@ function useProjects(currentParams: ProjectQueryParams) {
     [currentParams],
   );
 
-  // Initial load of projects - reset everything
+  // Fetch whenever params change
   useEffect(() => {
-    const initialPage = currentParams.page || 1;
-    setProjects([]);
-    setCurrentPage(initialPage);
-    setHasMore(true);
-    fetchProjects(initialPage, false);
+    const page = currentParams.page || 1;
+    fetchProjects(page);
   }, [
-    currentParams.featured, // Add featured to dependency array
+    currentParams.featured,
     currentParams.page,
     currentParams.title,
     currentParams.limit,
@@ -177,24 +154,14 @@ function useProjects(currentParams: ProjectQueryParams) {
     currentParams.sdgGoals?.join(","),
     currentParams.techStack?.join(","),
     currentParams.years?.join(","),
-    fetchProjects,
+    // NOTE: fetchProjects intentionally excluded to prevent re-render loops
   ]);
-
-  // Function to load more projects (called when user scrolls to bottom)
-  const loadMore = useCallback(() => {
-    // Don't allow load more for featured projects
-    if (!isLoading && hasMore && !currentParams.featured) {
-      fetchProjects(currentPage + 1, true);
-    }
-  }, [isLoading, hasMore, currentPage, currentParams.featured, fetchProjects]);
 
   return {
     projects,
     isLoading,
     error,
     meta,
-    hasMore,
-    loadMore,
   };
 }
 


### PR DESCRIPTION
This PR re-targets the previous pagination fix work to version-2-release and resolves pagination/infinite-scroll behavior regressions in public listing pages.

What changed
- Fixed infinite fetch loop behavior in project explorer.
- Fixed infinite fetch loop behavior in competitions listing.
- Preserved and respected current page query parameter during navigation.
- Prevented filter sidebar updates from resetting page unexpectedly when filters/search did not actually change.
- Improved pagination URL update logic to avoid unnecessary route pushes and repeated reload/fetch cycles.

Why
- The previous PR was opened against main and closed with a request to retarget version-2.
- These fixes are needed to ensure stable pagination and predictable navigation state in v2 listing experiences.

Scope
- Public projects listing pagination/search/filter flow.
- Public competitions listing infinite-scroll/pagination flow.
- Related query-param handling used by these pages.

Testing performed
- Verified page navigation updates URL page correctly.
- Verified applying unchanged filters does not reset page.
- Verified search/filter changes reset page only when expected.
- Verified no repeated infinite refetch loop after pagination or filter interactions.
- Verified behavior on both projects and competitions pages.

Notes
- Branch force-pushed after retargeting/replay onto version-2-release as requested.
- This PR supersedes the previously closed PR against main.