### PR TITLE
add student blog and award dashboard management

### DIFF
--- a/app/(student)/student/awards/[id]/edit/page.tsx
+++ b/app/(student)/student/awards/[id]/edit/page.tsx
@@ -1,0 +1,41 @@
+import type { Metadata } from 'next';
+import { redirect } from 'next/navigation';
+import { getServerSession } from 'next-auth';
+
+import StudentAwardForm from '@/components/student/StudentAwardForm';
+import { authOptions } from '@/app/api/auth/[...nextauth]/route';
+import { Role } from '@/types/prisma-types';
+
+export const metadata: Metadata = {
+  title: 'Edit Award | Student',
+};
+
+export default async function EditStudentAwardPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const session = await getServerSession(authOptions);
+
+  if (!session?.user) {
+    redirect('/login');
+  }
+
+  if (session.user.role !== Role.STUDENT) {
+    redirect('/unauthorized');
+  }
+
+  return (
+    <div className='space-y-6'>
+      <div>
+        <h1 className='text-3xl font-bold'>Edit Award Submission</h1>
+        <p className='text-muted-foreground'>
+          Update a pending or rejected award and send it back for moderation.
+        </p>
+      </div>
+
+      <StudentAwardForm awardId={id} />
+    </div>
+  );
+}

--- a/app/(student)/student/awards/new/page.tsx
+++ b/app/(student)/student/awards/new/page.tsx
@@ -1,0 +1,36 @@
+import type { Metadata } from 'next';
+import { redirect } from 'next/navigation';
+import { getServerSession } from 'next-auth';
+
+import StudentAwardForm from '@/components/student/StudentAwardForm';
+import { authOptions } from '@/app/api/auth/[...nextauth]/route';
+import { Role } from '@/types/prisma-types';
+
+export const metadata: Metadata = {
+  title: 'New Award | Student',
+};
+
+export default async function NewStudentAwardPage() {
+  const session = await getServerSession(authOptions);
+
+  if (!session?.user) {
+    redirect('/login');
+  }
+
+  if (session.user.role !== Role.STUDENT) {
+    redirect('/unauthorized');
+  }
+
+  return (
+    <div className='space-y-6'>
+      <div>
+        <h1 className='text-3xl font-bold'>Create Award Submission</h1>
+        <p className='text-muted-foreground'>
+          Attach a new award to one of your projects and submit it for review.
+        </p>
+      </div>
+
+      <StudentAwardForm />
+    </div>
+  );
+}

--- a/app/(student)/student/awards/page.tsx
+++ b/app/(student)/student/awards/page.tsx
@@ -1,0 +1,43 @@
+import type { Metadata } from 'next';
+import { redirect } from 'next/navigation';
+import { getServerSession } from 'next-auth';
+import Link from 'next/link';
+
+import StudentAwardsClient from '@/components/student/StudentAwardsClient';
+import { Button } from '@/components/ui/button';
+import { authOptions } from '@/app/api/auth/[...nextauth]/route';
+import { Role } from '@/types/prisma-types';
+
+export const metadata: Metadata = {
+  title: 'My Awards | Student',
+};
+
+export default async function StudentAwardsPage() {
+  const session = await getServerSession(authOptions);
+
+  if (!session?.user) {
+    redirect('/login');
+  }
+
+  if (session.user.role !== Role.STUDENT) {
+    redirect('/unauthorized');
+  }
+
+  return (
+    <div className='space-y-6'>
+      <div className='flex items-start justify-between gap-4'>
+        <div>
+          <h1 className='text-3xl font-bold'>My Awards</h1>
+          <p className='text-muted-foreground'>
+            Track awards linked to your projects and resubmit rejected entries.
+          </p>
+        </div>
+        <Button asChild>
+          <Link href='/student/awards/new'>New Award</Link>
+        </Button>
+      </div>
+
+      <StudentAwardsClient />
+    </div>
+  );
+}

--- a/app/(student)/student/blogs/[id]/edit/page.tsx
+++ b/app/(student)/student/blogs/[id]/edit/page.tsx
@@ -1,0 +1,41 @@
+import type { Metadata } from 'next';
+import { redirect } from 'next/navigation';
+import { getServerSession } from 'next-auth';
+
+import StudentBlogForm from '@/components/student/StudentBlogForm';
+import { authOptions } from '@/app/api/auth/[...nextauth]/route';
+import { Role } from '@/types/prisma-types';
+
+export const metadata: Metadata = {
+  title: 'Edit Blog | Student',
+};
+
+export default async function EditStudentBlogPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const session = await getServerSession(authOptions);
+
+  if (!session?.user) {
+    redirect('/login');
+  }
+
+  if (session.user.role !== Role.STUDENT) {
+    redirect('/unauthorized');
+  }
+
+  return (
+    <div className='space-y-6'>
+      <div>
+        <h1 className='text-3xl font-bold'>Edit Blog Post</h1>
+        <p className='text-muted-foreground'>
+          Update your draft or rejected post and send it back for review.
+        </p>
+      </div>
+
+      <StudentBlogForm blogId={id} />
+    </div>
+  );
+}

--- a/app/(student)/student/blogs/new/page.tsx
+++ b/app/(student)/student/blogs/new/page.tsx
@@ -1,0 +1,36 @@
+import type { Metadata } from 'next';
+import { redirect } from 'next/navigation';
+import { getServerSession } from 'next-auth';
+
+import StudentBlogForm from '@/components/student/StudentBlogForm';
+import { authOptions } from '@/app/api/auth/[...nextauth]/route';
+import { Role } from '@/types/prisma-types';
+
+export const metadata: Metadata = {
+  title: 'New Blog | Student',
+};
+
+export default async function NewStudentBlogPage() {
+  const session = await getServerSession(authOptions);
+
+  if (!session?.user) {
+    redirect('/login');
+  }
+
+  if (session.user.role !== Role.STUDENT) {
+    redirect('/unauthorized');
+  }
+
+  return (
+    <div className='space-y-6'>
+      <div>
+        <h1 className='text-3xl font-bold'>Create Blog Post</h1>
+        <p className='text-muted-foreground'>
+          Draft a new post and submit it for moderation from inside the student dashboard.
+        </p>
+      </div>
+
+      <StudentBlogForm />
+    </div>
+  );
+}

--- a/app/(student)/student/blogs/page.tsx
+++ b/app/(student)/student/blogs/page.tsx
@@ -1,0 +1,43 @@
+import type { Metadata } from 'next';
+import { redirect } from 'next/navigation';
+import { getServerSession } from 'next-auth';
+import Link from 'next/link';
+
+import StudentBlogsClient from '@/components/student/StudentBlogsClient';
+import { Button } from '@/components/ui/button';
+import { authOptions } from '@/app/api/auth/[...nextauth]/route';
+import { Role } from '@/types/prisma-types';
+
+export const metadata: Metadata = {
+  title: 'My Blogs | Student',
+};
+
+export default async function StudentBlogsPage() {
+  const session = await getServerSession(authOptions);
+
+  if (!session?.user) {
+    redirect('/login');
+  }
+
+  if (session.user.role !== Role.STUDENT) {
+    redirect('/unauthorized');
+  }
+
+  return (
+    <div className='space-y-6'>
+      <div className='flex items-start justify-between gap-4'>
+        <div>
+          <h1 className='text-3xl font-bold'>My Blogs</h1>
+          <p className='text-muted-foreground'>
+            Create, revise, and track the moderation state of your blog submissions.
+          </p>
+        </div>
+        <Button asChild>
+          <Link href='/student/blogs/new'>New Blog</Link>
+        </Button>
+      </div>
+
+      <StudentBlogsClient />
+    </div>
+  );
+}

--- a/app/(student)/student/page.tsx
+++ b/app/(student)/student/page.tsx
@@ -8,7 +8,7 @@ import { redirect } from 'next/navigation'
 import { getServerSession } from 'next-auth'
 import { authOptions } from '@/app/api/auth/[...nextauth]/route'
 import { Role } from '@/types/prisma-types'
-import { Rocket, Trophy, Award } from 'lucide-react'
+import { Rocket, Trophy, Award, BookOpen } from 'lucide-react'
 import StudentDashboardClient from '@/components/dashboard/StudentDashboardClient'
 
 export const metadata: Metadata = {
@@ -39,6 +39,22 @@ const actionCards = [
       'Been recognized for your achievements? Add your award to our showcase.',
     buttonLabel: 'Submit Award',
     href: '/submit/award',
+  },
+  {
+    icon: <BookOpen className='h-8 w-8' />,
+    title: 'Manage Blogs',
+    description:
+      'Create new blog posts, edit rejected drafts, and keep an eye on moderation status.',
+    buttonLabel: 'Open Blogs',
+    href: '/student/blogs',
+  },
+  {
+    icon: <Award className='h-8 w-8' />,
+    title: 'Manage Awards',
+    description:
+      'Review your award submissions, fix rejected entries, and resubmit them from one place.',
+    buttonLabel: 'Open Awards',
+    href: '/student/awards',
   },
 ]
 

--- a/app/api/admin/user/create/route.ts
+++ b/app/api/admin/user/create/route.ts
@@ -7,9 +7,10 @@ import bcrypt from 'bcryptjs';
 
 // Schema for validating user creation
 const userCreateSchema = z.object({
+  email: z.string().email('A valid email is required'),
   name: z.string().min(2, 'Name must be at least 2 characters'),
   password: z.string().min(8, 'Password must be at least 8 characters'),
-  role: z.enum(['ADMIN', 'MODERATOR', 'DEVELOPER']),
+  role: z.enum(['ADMIN', 'MODERATOR', 'DEVELOPER', 'STUDENT']),
 });
 
 export async function POST(req: Request) {
@@ -40,13 +41,15 @@ export async function POST(req: Request) {
         { error: validationResult.error.errors },
         { status: 400 }
       );
-    }    const { name, password, role } = validationResult.data;
+    }
 
-    // Check if user with the same name already exists
-    const existingUser = await prisma.user.findFirst({ where: { name } });
+    const { email, name, password, role } = validationResult.data;
+
+    // Check if user with the same email already exists
+    const existingUser = await prisma.user.findUnique({ where: { email } });
     if (existingUser) {
       return NextResponse.json(
-        { error: "User with this name already exists" },
+        { error: "User with this email already exists" },
         { status: 400 }
       );
     }
@@ -57,6 +60,7 @@ export async function POST(req: Request) {
     // Create user
     const newUser = await prisma.user.create({
       data: {
+        email,
         name,
         password: hashedPassword,
         role,
@@ -75,10 +79,10 @@ export async function POST(req: Request) {
     console.error("Error creating user:", error);
     const errorMessage =
       (error as any)?.message && (error as any)?.message.includes("Unique constraint failed")
-        ? "User with this name already exists"
+        ? "User with this email already exists"
         : "Failed to create user";
 
-    const statusCode = errorMessage === "User with this name already exists" ? 400 : 500;
+    const statusCode = errorMessage === "User with this email already exists" ? 400 : 500;
 
     return NextResponse.json(
       { error: errorMessage },

--- a/app/api/student/awards/[id]/route.ts
+++ b/app/api/student/awards/[id]/route.ts
@@ -1,0 +1,170 @@
+import { NextResponse } from "next/server";
+
+import { prisma } from "@/prisma/prismaClient";
+import { getStudentSessionUser } from "@/lib/student-dashboard/session";
+import { ApprovalStatus } from "@/types/prisma-types";
+import { awardPayloadSchema } from "@/validations/award";
+
+async function getOwnedAward(awardId: string, userId: string) {
+  return prisma.award.findFirst({
+    where: {
+      id: awardId,
+      project: {
+        is: {
+          owner_userId: userId,
+        },
+      },
+    },
+    include: {
+      competition: true,
+      project: true,
+    },
+  });
+}
+
+async function ensureOwnedProject(projectId: string, userId: string) {
+  return prisma.projectMetadata.findFirst({
+    where: {
+      project_id: projectId,
+      owner_userId: userId,
+    },
+    select: {
+      project_id: true,
+    },
+  });
+}
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const auth = await getStudentSessionUser();
+  if (auth.response) return auth.response;
+
+  try {
+    const { id } = await params;
+    const award = await getOwnedAward(id, auth.user.id);
+
+    if (!award) {
+      return NextResponse.json({ error: "Award not found" }, { status: 404 });
+    }
+
+    return NextResponse.json({ data: award });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    return NextResponse.json(
+      { error: "Failed to fetch student award", details: message },
+      { status: 500 }
+    );
+  }
+}
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const auth = await getStudentSessionUser();
+  if (auth.response) return auth.response;
+
+  try {
+    const { id } = await params;
+    const existing = await getOwnedAward(id, auth.user.id);
+
+    if (!existing) {
+      return NextResponse.json({ error: "Award not found" }, { status: 404 });
+    }
+
+    if (existing.approval_status === ApprovalStatus.APPROVED) {
+      return NextResponse.json(
+        { error: "Approved awards cannot be edited from the student dashboard" },
+        { status: 409 }
+      );
+    }
+
+    const body = await request.json();
+    const validatedData = awardPayloadSchema.parse(body);
+
+    const ownedProject = await ensureOwnedProject(validatedData.projectId, auth.user.id);
+    if (!ownedProject) {
+      return NextResponse.json({ error: "Project not found" }, { status: 404 });
+    }
+
+    const competition = await prisma.competition.findUnique({
+      where: { id: validatedData.competitionId },
+      select: { id: true },
+    });
+
+    if (!competition) {
+      return NextResponse.json({ error: "Competition not found" }, { status: 404 });
+    }
+
+    const updated = await prisma.award.update({
+      where: { id },
+      data: {
+        name: validatedData.awardName,
+        image: validatedData.image,
+        competition_id: validatedData.competitionId,
+        project_id: validatedData.projectId,
+        approval_status: ApprovalStatus.PENDING,
+        accepted_by_id: null,
+        rejected_by_id: null,
+        rejected_reason: null,
+      },
+      include: {
+        competition: true,
+        project: true,
+      },
+    });
+
+    return NextResponse.json({ data: updated });
+  } catch (error: any) {
+    if (error?.name === "ZodError") {
+      return NextResponse.json(
+        { error: "Invalid request data", details: error.errors },
+        { status: 400 }
+      );
+    }
+
+    const message = error instanceof Error ? error.message : "Unknown error";
+    return NextResponse.json(
+      { error: "Failed to update student award", details: message },
+      { status: 500 }
+    );
+  }
+}
+
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const auth = await getStudentSessionUser();
+  if (auth.response) return auth.response;
+
+  try {
+    const { id } = await params;
+    const existing = await getOwnedAward(id, auth.user.id);
+
+    if (!existing) {
+      return NextResponse.json({ error: "Award not found" }, { status: 404 });
+    }
+
+    if (existing.approval_status === ApprovalStatus.APPROVED) {
+      return NextResponse.json(
+        { error: "Approved awards cannot be deleted from the student dashboard" },
+        { status: 409 }
+      );
+    }
+
+    await prisma.award.delete({
+      where: { id },
+    });
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    return NextResponse.json(
+      { error: "Failed to delete student award", details: message },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/student/awards/route.ts
+++ b/app/api/student/awards/route.ts
@@ -1,0 +1,143 @@
+import { NextResponse } from "next/server";
+
+import { prisma } from "@/prisma/prismaClient";
+import { getStudentSessionUser } from "@/lib/student-dashboard/session";
+import { ApprovalStatus } from "@/types/prisma-types";
+import { awardPayloadSchema } from "@/validations/award";
+
+function applyAwardStatusFilter(where: Record<string, unknown>, status: string | null) {
+  if (status === "pending") {
+    where.approval_status = ApprovalStatus.PENDING;
+  } else if (status === "approved") {
+    where.approval_status = ApprovalStatus.APPROVED;
+  } else if (status === "rejected") {
+    where.approval_status = ApprovalStatus.REJECTED;
+  }
+}
+
+async function ensureOwnedProject(projectId: string, userId: string) {
+  return prisma.projectMetadata.findFirst({
+    where: {
+      project_id: projectId,
+      owner_userId: userId,
+    },
+    select: {
+      project_id: true,
+    },
+  });
+}
+
+export async function GET(request: Request) {
+  const auth = await getStudentSessionUser();
+  if (auth.response) return auth.response;
+
+  try {
+    const { searchParams } = new URL(request.url);
+    const page = Math.max(parseInt(searchParams.get("page") || "1", 10), 1);
+    const limit = Math.max(parseInt(searchParams.get("limit") || "20", 10), 1);
+    const skip = (page - 1) * limit;
+    const status = searchParams.get("status");
+
+    const where: Record<string, unknown> = {
+      project: {
+        is: {
+          owner_userId: auth.user.id,
+        },
+      },
+    };
+
+    applyAwardStatusFilter(where, status);
+
+    const [total, awards] = await Promise.all([
+      prisma.award.count({ where }),
+      prisma.award.findMany({
+        where,
+        skip,
+        take: limit,
+        orderBy: { updatedAt: "desc" },
+        include: {
+          competition: true,
+          project: true,
+        },
+      }),
+    ]);
+
+    return NextResponse.json({
+      data: awards,
+      metadata: {
+        currentPage: page,
+        itemsPerPage: limit,
+        totalItems: total,
+        totalPages: Math.ceil(total / limit),
+      },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    return NextResponse.json(
+      { error: "Failed to fetch student awards", details: message },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(request: Request) {
+  const auth = await getStudentSessionUser();
+  if (auth.response) return auth.response;
+
+  try {
+    const body = await request.json();
+    const validatedData = awardPayloadSchema.parse(body);
+
+    const ownedProject = await ensureOwnedProject(validatedData.projectId, auth.user.id);
+    if (!ownedProject) {
+      return NextResponse.json(
+        { error: "Project not found" },
+        { status: 404 }
+      );
+    }
+
+    const competition = await prisma.competition.findUnique({
+      where: { id: validatedData.competitionId },
+      select: { id: true },
+    });
+
+    if (!competition) {
+      return NextResponse.json(
+        { error: "Competition not found" },
+        { status: 404 }
+      );
+    }
+
+    const award = await prisma.award.create({
+      data: {
+        name: validatedData.awardName,
+        image: validatedData.image,
+        competition_id: validatedData.competitionId,
+        project_id: validatedData.projectId,
+        approval_status: ApprovalStatus.PENDING,
+        accepted_by_id: null,
+        rejected_by_id: null,
+        rejected_reason: null,
+      },
+      include: {
+        competition: true,
+        project: true,
+      },
+    });
+
+    return NextResponse.json({ data: award }, { status: 201 });
+  } catch (error: any) {
+    if (error?.name === "ZodError") {
+      return NextResponse.json(
+        { error: "Invalid request data", details: error.errors },
+        { status: 400 }
+      );
+    }
+
+    const message = error instanceof Error ? error.message : "Unknown error";
+    return NextResponse.json(
+      { error: "Failed to create student award", details: message },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/student/blogs/[id]/route.ts
+++ b/app/api/student/blogs/[id]/route.ts
@@ -1,0 +1,178 @@
+import { NextResponse } from "next/server";
+
+import { prisma } from "@/prisma/prismaClient";
+import { blogSubmissionSchema } from "@/validations/blog";
+import { getStudentSessionUser } from "@/lib/student-dashboard/session";
+
+async function getOwnedBlog(blogId: string, email: string) {
+  return prisma.blogPost.findFirst({
+    where: {
+      id: blogId,
+      author: {
+        is: {
+          email,
+        },
+      },
+    },
+    include: {
+      author: true,
+    },
+  });
+}
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const auth = await getStudentSessionUser();
+  if (auth.response) return auth.response;
+
+  try {
+    const { id } = await params;
+    const post = await getOwnedBlog(id, auth.user.email);
+
+    if (!post) {
+      return NextResponse.json({ error: "Blog post not found" }, { status: 404 });
+    }
+
+    return NextResponse.json({ data: post });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    return NextResponse.json(
+      { error: "Failed to fetch student blog", details: message },
+      { status: 500 }
+    );
+  }
+}
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const auth = await getStudentSessionUser();
+  if (auth.response) return auth.response;
+
+  try {
+    const { id } = await params;
+    const existing = await getOwnedBlog(id, auth.user.email);
+
+    if (!existing) {
+      return NextResponse.json({ error: "Blog post not found" }, { status: 404 });
+    }
+
+    if (existing.approved) {
+      return NextResponse.json(
+        { error: "Approved blog posts cannot be edited from the student dashboard" },
+        { status: 409 }
+      );
+    }
+
+    const body = await request.json();
+    const validatedData = blogSubmissionSchema.parse(body);
+
+    if (validatedData.author.email !== auth.user.email) {
+      return NextResponse.json(
+        { error: "Blog author email must match the logged-in student" },
+        { status: 403 }
+      );
+    }
+
+    const updated = await prisma.$transaction(async (tx) => {
+      const author = await tx.blogAuthor.upsert({
+        where: { email: auth.user.email },
+        update: {
+          name: validatedData.author.name,
+          avatarUrl: validatedData.author.avatarUrl || null,
+          instagram: validatedData.author.instagram || null,
+          twitter: validatedData.author.twitter || null,
+          facebook: validatedData.author.facebook || null,
+          linkedin: validatedData.author.linkedin || null,
+          medium: validatedData.author.medium || null,
+          website: validatedData.author.website || null,
+        },
+        create: {
+          name: validatedData.author.name,
+          email: auth.user.email,
+          avatarUrl: validatedData.author.avatarUrl || null,
+          instagram: validatedData.author.instagram || null,
+          twitter: validatedData.author.twitter || null,
+          facebook: validatedData.author.facebook || null,
+          linkedin: validatedData.author.linkedin || null,
+          medium: validatedData.author.medium || null,
+          website: validatedData.author.website || null,
+        },
+      });
+
+      return tx.blogPost.update({
+        where: { id },
+        data: {
+          title: validatedData.post.title,
+          excerpt: validatedData.post.excerpt,
+          content: validatedData.post.content,
+          imageUrl: validatedData.post.imageUrl || null,
+          category: validatedData.post.category,
+          featured: false,
+          approved: false,
+          approvedById: null,
+          rejectedById: null,
+          rejectedReason: null,
+          authorId: author.id,
+        },
+        include: {
+          author: true,
+        },
+      });
+    });
+
+    return NextResponse.json({ data: updated });
+  } catch (error: any) {
+    if (error?.name === "ZodError") {
+      return NextResponse.json(
+        { error: "Invalid request data", details: error.errors },
+        { status: 400 }
+      );
+    }
+
+    const message = error instanceof Error ? error.message : "Unknown error";
+    return NextResponse.json(
+      { error: "Failed to update student blog", details: message },
+      { status: 500 }
+    );
+  }
+}
+
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const auth = await getStudentSessionUser();
+  if (auth.response) return auth.response;
+
+  try {
+    const { id } = await params;
+    const existing = await getOwnedBlog(id, auth.user.email);
+
+    if (!existing) {
+      return NextResponse.json({ error: "Blog post not found" }, { status: 404 });
+    }
+
+    if (existing.approved) {
+      return NextResponse.json(
+        { error: "Approved blog posts cannot be deleted from the student dashboard" },
+        { status: 409 }
+      );
+    }
+
+    await prisma.blogPost.delete({
+      where: { id },
+    });
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    return NextResponse.json(
+      { error: "Failed to delete student blog", details: message },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/student/blogs/route.ts
+++ b/app/api/student/blogs/route.ts
@@ -1,0 +1,147 @@
+import { NextResponse } from "next/server";
+
+import { prisma } from "@/prisma/prismaClient";
+import { blogSubmissionSchema } from "@/validations/blog";
+import { getStudentSessionUser } from "@/lib/student-dashboard/session";
+
+function applyBlogStatusFilter(where: Record<string, unknown>, status: string | null) {
+  if (status === "pending") {
+    where.approved = false;
+    where.rejectedById = null;
+  } else if (status === "approved") {
+    where.approved = true;
+  } else if (status === "rejected") {
+    where.approved = false;
+    where.rejectedById = { not: null };
+  }
+}
+
+export async function GET(request: Request) {
+  const auth = await getStudentSessionUser();
+  if (auth.response) return auth.response;
+
+  try {
+    const { searchParams } = new URL(request.url);
+    const page = Math.max(parseInt(searchParams.get("page") || "1", 10), 1);
+    const limit = Math.max(parseInt(searchParams.get("limit") || "20", 10), 1);
+    const skip = (page - 1) * limit;
+    const status = searchParams.get("status");
+
+    const where: Record<string, unknown> = {
+      author: {
+        is: {
+          email: auth.user.email,
+        },
+      },
+    };
+
+    applyBlogStatusFilter(where, status);
+
+    const [total, posts] = await Promise.all([
+      prisma.blogPost.count({ where }),
+      prisma.blogPost.findMany({
+        where,
+        orderBy: { updatedAt: "desc" },
+        skip,
+        take: limit,
+        include: {
+          author: true,
+        },
+      }),
+    ]);
+
+    return NextResponse.json({
+      data: posts,
+      metadata: {
+        currentPage: page,
+        itemsPerPage: limit,
+        totalItems: total,
+        totalPages: Math.ceil(total / limit),
+      },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    return NextResponse.json(
+      { error: "Failed to fetch student blogs", details: message },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(request: Request) {
+  const auth = await getStudentSessionUser();
+  if (auth.response) return auth.response;
+
+  try {
+    const body = await request.json();
+    const validatedData = blogSubmissionSchema.parse(body);
+
+    if (validatedData.author.email !== auth.user.email) {
+      return NextResponse.json(
+        { error: "Blog author email must match the logged-in student" },
+        { status: 403 }
+      );
+    }
+
+    const result = await prisma.$transaction(async (tx) => {
+      const author = await tx.blogAuthor.upsert({
+        where: { email: auth.user.email },
+        update: {
+          name: validatedData.author.name,
+          avatarUrl: validatedData.author.avatarUrl || null,
+          instagram: validatedData.author.instagram || null,
+          twitter: validatedData.author.twitter || null,
+          facebook: validatedData.author.facebook || null,
+          linkedin: validatedData.author.linkedin || null,
+          medium: validatedData.author.medium || null,
+          website: validatedData.author.website || null,
+        },
+        create: {
+          name: validatedData.author.name,
+          email: auth.user.email,
+          avatarUrl: validatedData.author.avatarUrl || null,
+          instagram: validatedData.author.instagram || null,
+          twitter: validatedData.author.twitter || null,
+          facebook: validatedData.author.facebook || null,
+          linkedin: validatedData.author.linkedin || null,
+          medium: validatedData.author.medium || null,
+          website: validatedData.author.website || null,
+        },
+      });
+
+      return tx.blogPost.create({
+        data: {
+          title: validatedData.post.title,
+          excerpt: validatedData.post.excerpt,
+          content: validatedData.post.content,
+          imageUrl: validatedData.post.imageUrl || null,
+          category: validatedData.post.category,
+          featured: false,
+          approved: false,
+          approvedById: null,
+          rejectedById: null,
+          rejectedReason: null,
+          authorId: author.id,
+        },
+        include: {
+          author: true,
+        },
+      });
+    });
+
+    return NextResponse.json(result, { status: 201 });
+  } catch (error: any) {
+    if (error?.name === "ZodError") {
+      return NextResponse.json(
+        { error: "Invalid request data", details: error.errors },
+        { status: 400 }
+      );
+    }
+
+    const message = error instanceof Error ? error.message : "Unknown error";
+    return NextResponse.json(
+      { error: "Failed to create student blog", details: message },
+      { status: 500 }
+    );
+  }
+}

--- a/components/layout/student-sidebar.tsx
+++ b/components/layout/student-sidebar.tsx
@@ -3,7 +3,7 @@
 import { usePathname } from 'next/navigation';
 import Link from 'next/link';
 import { cn } from '@/lib/utils';
-import { LayoutDashboard, Upload } from 'lucide-react';
+import { Award, BookOpen, LayoutDashboard, Upload } from 'lucide-react';
 
 const sidebarItems = [
   {
@@ -20,6 +20,16 @@ const sidebarItems = [
     title: 'Projects',
     href: '/student/projects',
     icon: LayoutDashboard,
+  },
+  {
+    title: 'Blogs',
+    href: '/student/blogs',
+    icon: BookOpen,
+  },
+  {
+    title: 'Awards',
+    href: '/student/awards',
+    icon: Award,
   },
 ];
 

--- a/components/student/StudentAwardForm.tsx
+++ b/components/student/StudentAwardForm.tsx
@@ -1,0 +1,319 @@
+'use client';
+
+import { ApprovalStatus } from '@/types/prisma-types';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+import { toast } from 'sonner';
+
+import { AwardStatusBadge } from '@/components/student/status-badges';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Skeleton } from '@/components/ui/skeleton';
+import { awardPayloadSchema } from '@/validations/award';
+import useUploadImageToBlob from '@/hooks/azure/useUploadImageToBlob';
+
+type StudentAwardFormProps = {
+  awardId?: string;
+};
+
+type Option = {
+  id: string;
+  label: string;
+  sublabel?: string;
+};
+
+type AwardPayload = {
+  projectId: string;
+  competitionId: string;
+  awardName: string;
+  image: string;
+  approvalStatus?: ApprovalStatus;
+  rejectedReason?: string | null;
+};
+
+export default function StudentAwardForm({ awardId }: StudentAwardFormProps) {
+  const router = useRouter();
+  const { uploadImage } = useUploadImageToBlob();
+
+  const [projects, setProjects] = useState<Option[]>([]);
+  const [competitions, setCompetitions] = useState<Option[]>([]);
+  const [formData, setFormData] = useState<AwardPayload>({
+    projectId: '',
+    competitionId: '',
+    awardName: '',
+    image: '',
+  });
+  const [pendingImageFile, setPendingImageFile] = useState<File | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+
+  useEffect(() => {
+    const load = async () => {
+      setIsLoading(true);
+      setErrorMessage(null);
+
+      try {
+        const [projectResponse, competitionResponse, awardResponse] = await Promise.all([
+          fetch('/api/student/projects?page=1&limit=100'),
+          fetch('/api/competition/search?limit=20'),
+          awardId ? fetch(`/api/student/awards/${awardId}`) : Promise.resolve(null),
+        ]);
+
+        const projectPayload = await projectResponse.json();
+        if (!projectResponse.ok) {
+          throw new Error(projectPayload?.error || 'Failed to load your projects');
+        }
+
+        const competitionPayload = await competitionResponse.json();
+        if (!competitionResponse.ok) {
+          throw new Error(competitionPayload?.error || 'Failed to load competitions');
+        }
+
+        const projectOptions: Option[] = (projectPayload.data ?? []).map((project: any) => ({
+          id: project.projectId,
+          label: project.title,
+          sublabel: `${project.groupNum} | ${project.year}`,
+        }));
+
+        let competitionOptions: Option[] = (competitionPayload ?? []).map((competition: any) => ({
+          id: competition.id,
+          label: competition.name,
+          sublabel: [competition.start_date, competition.end_date]
+            .filter(Boolean)
+            .map((value: string) => new Date(value).toLocaleDateString())
+            .join(' - '),
+        }));
+
+        setProjects(projectOptions);
+
+        if (awardId) {
+          if (!awardResponse) {
+            throw new Error('Failed to load award');
+          }
+
+          const awardPayload = await awardResponse.json();
+          if (!awardResponse.ok) {
+            throw new Error(awardPayload?.error || 'Failed to load award');
+          }
+
+          const award = awardPayload.data;
+          setFormData({
+            projectId: award.project_id,
+            competitionId: award.competition_id,
+            awardName: award.name,
+            image: award.image ?? '',
+            approvalStatus: award.approval_status,
+            rejectedReason: award.rejected_reason ?? null,
+          });
+
+          if (!competitionOptions.some((option) => option.id === award.competition.id)) {
+            competitionOptions = [
+              ...competitionOptions,
+              {
+                id: award.competition.id,
+                label: award.competition.name,
+              },
+            ];
+          }
+        }
+
+        setCompetitions(competitionOptions);
+      } catch (error) {
+        setErrorMessage(error instanceof Error ? error.message : 'Failed to load award form');
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    void load();
+  }, [awardId]);
+
+  const handleSubmit = async () => {
+    setIsSaving(true);
+    setErrorMessage(null);
+    setFieldErrors({});
+
+    try {
+      let imageUrl = formData.image;
+      if (pendingImageFile) {
+        imageUrl = await uploadImage(pendingImageFile);
+      }
+
+      const payload = {
+        projectId: formData.projectId,
+        competitionId: formData.competitionId,
+        awardName: formData.awardName,
+        image: imageUrl,
+      };
+
+      const validation = awardPayloadSchema.safeParse(payload);
+      if (!validation.success) {
+        const errors: Record<string, string> = {};
+        for (const issue of validation.error.errors) {
+          const key = Array.isArray(issue.path) ? issue.path.join('.') : String(issue.path);
+          errors[key] = issue.message;
+        }
+        setFieldErrors(errors);
+        setIsSaving(false);
+        return;
+      }
+
+      const response = await fetch(awardId ? `/api/student/awards/${awardId}` : '/api/student/awards', {
+        method: awardId ? 'PATCH' : 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(payload),
+      });
+
+      const result = await response.json();
+      if (!response.ok) {
+        throw new Error(result?.error || 'Failed to save award');
+      }
+
+      toast.success(awardId ? 'Award updated' : 'Award created');
+      router.push('/student/awards');
+      router.refresh();
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : 'Failed to save award');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className='space-y-4'>
+        <Skeleton className='h-10 w-full' />
+        <Skeleton className='h-10 w-full' />
+        <Skeleton className='h-48 w-full' />
+      </div>
+    );
+  }
+
+  return (
+    <div className='space-y-6'>
+      {awardId && formData.approvalStatus ? (
+        <div className='flex items-center gap-3'>
+          <AwardStatusBadge status={formData.approvalStatus} />
+          {formData.rejectedReason ? (
+            <p className='text-destructive text-sm'>Reason: {formData.rejectedReason}</p>
+          ) : null}
+        </div>
+      ) : null}
+
+      {errorMessage ? (
+        <Alert variant='destructive'>
+          <AlertTitle>Error</AlertTitle>
+          <AlertDescription>{errorMessage}</AlertDescription>
+        </Alert>
+      ) : null}
+
+      <div className='space-y-4 rounded-xl border p-5'>
+        <div>
+          <h2 className='text-xl font-semibold'>Award Details</h2>
+          <p className='text-muted-foreground text-sm'>
+            Awards are tied to projects you own. Editing a rejected award sends it back for review.
+          </p>
+        </div>
+
+        <div className='grid gap-4 md:grid-cols-2'>
+          <div className='space-y-2'>
+            <Label>Project</Label>
+            <select
+              value={formData.projectId}
+              onChange={(event) => setFormData((current) => ({ ...current, projectId: event.target.value }))}
+              className='border-input bg-background ring-offset-background flex h-10 w-full rounded-md border px-3 py-2 text-sm'
+            >
+              <option value=''>Select one of your projects</option>
+              {projects.map((project) => (
+                <option key={project.id} value={project.id}>
+                  {project.label}{project.sublabel ? ` (${project.sublabel})` : ''}
+                </option>
+              ))}
+            </select>
+            {fieldErrors.projectId ? (
+              <p className='text-destructive text-xs'>{fieldErrors.projectId}</p>
+            ) : null}
+          </div>
+
+          <div className='space-y-2'>
+            <Label>Competition</Label>
+            <select
+              value={formData.competitionId}
+              onChange={(event) =>
+                setFormData((current) => ({ ...current, competitionId: event.target.value }))
+              }
+              className='border-input bg-background ring-offset-background flex h-10 w-full rounded-md border px-3 py-2 text-sm'
+            >
+              <option value=''>Select a competition</option>
+              {competitions.map((competition) => (
+                <option key={competition.id} value={competition.id}>
+                  {competition.label}{competition.sublabel ? ` (${competition.sublabel})` : ''}
+                </option>
+              ))}
+            </select>
+            {fieldErrors.competitionId ? (
+              <p className='text-destructive text-xs'>{fieldErrors.competitionId}</p>
+            ) : null}
+          </div>
+        </div>
+
+        <div className='space-y-2'>
+          <Label htmlFor='award-name'>Award Name</Label>
+          <Input
+            id='award-name'
+            value={formData.awardName}
+            onChange={(event) => setFormData((current) => ({ ...current, awardName: event.target.value }))}
+            placeholder='Best Innovation Award'
+          />
+          {fieldErrors.awardName ? (
+            <p className='text-destructive text-xs'>{fieldErrors.awardName}</p>
+          ) : null}
+        </div>
+
+        <div className='space-y-2'>
+          <Label>Award Image</Label>
+          <Input
+            type='file'
+            accept='image/png,image/jpeg'
+            onChange={(event) => {
+              const file = event.target.files?.[0] ?? null;
+              setPendingImageFile(file);
+              if (file) {
+                setFormData((current) => ({
+                  ...current,
+                  image: URL.createObjectURL(file),
+                }));
+              }
+            }}
+          />
+          {fieldErrors.image ? (
+            <p className='text-destructive text-xs'>{fieldErrors.image}</p>
+          ) : null}
+          {formData.image ? (
+            <img
+              src={formData.image}
+              alt='Award preview'
+              className='max-h-72 rounded-lg border object-contain'
+            />
+          ) : null}
+        </div>
+
+        <div className='flex flex-wrap gap-3'>
+          <Button onClick={() => void handleSubmit()} disabled={isSaving}>
+            {isSaving ? 'Saving...' : awardId ? 'Save Changes' : 'Create Award'}
+          </Button>
+          <Button variant='outline' asChild>
+            <Link href='/student/awards'>Cancel</Link>
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/student/StudentAwardsClient.tsx
+++ b/components/student/StudentAwardsClient.tsx
@@ -1,0 +1,199 @@
+'use client';
+
+import { ApprovalStatus } from '@/types/prisma-types';
+import Link from 'next/link';
+import { useCallback, useEffect, useState } from 'react';
+import { toast } from 'sonner';
+
+import { AwardStatusBadge } from '@/components/student/status-badges';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
+
+type AwardFilter = 'all' | 'pending' | 'approved' | 'rejected';
+
+type StudentAwardRow = {
+  id: string;
+  name: string;
+  image: string | null;
+  approval_status: ApprovalStatus;
+  rejected_reason: string | null;
+  createdAt: string;
+  project: {
+    project_id: string;
+    title: string;
+  };
+  competition: {
+    id: string;
+    name: string;
+  };
+};
+
+export default function StudentAwardsClient() {
+  const [filter, setFilter] = useState<AwardFilter>('all');
+  const [awards, setAwards] = useState<StudentAwardRow[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const loadAwards = useCallback(async (status: AwardFilter) => {
+    setIsLoading(true);
+    setErrorMessage(null);
+
+    try {
+      const params = new URLSearchParams({
+        page: '1',
+        limit: '50',
+      });
+
+      if (status !== 'all') {
+        params.set('status', status);
+      }
+
+      const response = await fetch(`/api/student/awards?${params.toString()}`);
+      const payload = await response.json();
+
+      if (!response.ok) {
+        throw new Error(payload?.error || 'Failed to load awards');
+      }
+
+      setAwards(payload.data ?? []);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to load awards';
+      setErrorMessage(message);
+      setAwards([]);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadAwards(filter);
+  }, [filter, loadAwards]);
+
+  const handleDelete = async (awardId: string) => {
+    if (!window.confirm('Delete this award submission?')) return;
+
+    try {
+      const response = await fetch(`/api/student/awards/${awardId}`, {
+        method: 'DELETE',
+      });
+      const payload = await response.json();
+
+      if (!response.ok) {
+        throw new Error(payload?.error || 'Failed to delete award');
+      }
+
+      toast.success('Award deleted');
+      await loadAwards(filter);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to delete award');
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className='space-y-3'>
+        <Skeleton className='h-9 w-80' />
+        <Skeleton className='h-10 w-full' />
+        <Skeleton className='h-10 w-full' />
+        <Skeleton className='h-10 w-full' />
+      </div>
+    );
+  }
+
+  if (errorMessage) {
+    return (
+      <Alert variant='destructive'>
+        <AlertTitle>Error</AlertTitle>
+        <AlertDescription>{errorMessage}</AlertDescription>
+      </Alert>
+    );
+  }
+
+  return (
+    <div className='space-y-4'>
+      <Tabs value={filter} onValueChange={(value) => setFilter(value as AwardFilter)}>
+        <TabsList>
+          <TabsTrigger value='all'>All</TabsTrigger>
+          <TabsTrigger value='pending'>Pending</TabsTrigger>
+          <TabsTrigger value='approved'>Approved</TabsTrigger>
+          <TabsTrigger value='rejected'>Rejected</TabsTrigger>
+        </TabsList>
+      </Tabs>
+
+      {awards.length === 0 ? (
+        <Alert>
+          <AlertTitle>No awards yet</AlertTitle>
+          <AlertDescription>
+            Award submissions linked to your projects will appear here.
+          </AlertDescription>
+        </Alert>
+      ) : (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Award</TableHead>
+              <TableHead>Project</TableHead>
+              <TableHead>Competition</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead className='text-right'>Actions</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {awards.map((award) => {
+              const isEditable = award.approval_status !== ApprovalStatus.APPROVED;
+
+              return (
+                <TableRow key={award.id}>
+                  <TableCell className='space-y-1'>
+                    <div className='font-medium'>{award.name}</div>
+                    <div className='text-muted-foreground text-sm'>
+                      Submitted {new Date(award.createdAt).toLocaleDateString()}
+                    </div>
+                    {award.approval_status === ApprovalStatus.REJECTED && award.rejected_reason ? (
+                      <div className='text-destructive text-xs'>
+                        Reason: {award.rejected_reason}
+                      </div>
+                    ) : null}
+                  </TableCell>
+                  <TableCell>{award.project.title}</TableCell>
+                  <TableCell>{award.competition.name}</TableCell>
+                  <TableCell>
+                    <AwardStatusBadge status={award.approval_status} />
+                  </TableCell>
+                  <TableCell className='text-right'>
+                    <div className='flex justify-end gap-2'>
+                      <Button size='sm' variant='outline' asChild>
+                        <Link href={`/project/${award.project.project_id}`}>View</Link>
+                      </Button>
+                      {isEditable ? (
+                        <Button size='sm' variant='outline' asChild>
+                          <Link href={`/student/awards/${award.id}/edit`}>Edit</Link>
+                        </Button>
+                      ) : (
+                        <Button size='sm' variant='outline' disabled>
+                          Edit
+                        </Button>
+                      )}
+                      {isEditable ? (
+                        <Button
+                          size='sm'
+                          variant='destructive'
+                          onClick={() => void handleDelete(award.id)}
+                        >
+                          Delete
+                        </Button>
+                      ) : null}
+                    </div>
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      )}
+    </div>
+  );
+}

--- a/components/student/StudentBlogForm.tsx
+++ b/components/student/StudentBlogForm.tsx
@@ -1,0 +1,521 @@
+'use client';
+
+import { ProjectDomainEnum } from '@/types/prisma-types';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useSession } from 'next-auth/react';
+import { useEffect, useMemo, useState } from 'react';
+import { toast } from 'sonner';
+
+import MarkdownEditor from '@/components/blog/MarkdownEditor';
+import MarkdownPreview from '@/components/blog/MarkdownPreview';
+import { BlogStatusBadge } from '@/components/student/status-badges';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Textarea } from '@/components/ui/textarea';
+import useUploadImageToBlob from '@/hooks/azure/useUploadImageToBlob';
+import { blogSubmissionSchema } from '@/validations/blog';
+
+type StudentBlogFormProps = {
+  blogId?: string;
+};
+
+type BlogPayload = {
+  author: {
+    name: string;
+    email: string;
+    avatarUrl: string;
+    instagram: string;
+    twitter: string;
+    facebook: string;
+    linkedin: string;
+    medium: string;
+    website: string;
+  };
+  post: {
+    title: string;
+    excerpt: string;
+    content: string;
+    imageUrl: string;
+    category: string;
+  };
+  approved?: boolean;
+  rejectedById?: string | null;
+  rejectedReason?: string | null;
+};
+
+const categoryOptions = Object.values(ProjectDomainEnum);
+
+const emptyPayload = (email = '', name = ''): BlogPayload => ({
+  author: {
+    name,
+    email,
+    avatarUrl: '',
+    instagram: '',
+    twitter: '',
+    facebook: '',
+    linkedin: '',
+    medium: '',
+    website: '',
+  },
+  post: {
+    title: '',
+    excerpt: '',
+    content: '',
+    imageUrl: '',
+    category: '',
+  },
+});
+
+function mapZodErrors(error: any) {
+  const result: Record<string, string> = {};
+
+  for (const issue of error?.errors ?? []) {
+    const key = Array.isArray(issue.path) ? issue.path.join('.') : issue.path;
+    if (key) {
+      result[key] = issue.message;
+    }
+  }
+
+  return result;
+}
+
+export default function StudentBlogForm({ blogId }: StudentBlogFormProps) {
+  const router = useRouter();
+  const { data: session, status } = useSession();
+  const { uploadImage } = useUploadImageToBlob();
+
+  const [formData, setFormData] = useState<BlogPayload>(emptyPayload());
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+
+  const previewStatus = useMemo(
+    () => ({
+      approved: !!formData.approved,
+      rejectedById: formData.rejectedById,
+    }),
+    [formData.approved, formData.rejectedById]
+  );
+
+  useEffect(() => {
+    const load = async () => {
+      if (status !== "authenticated") return;
+
+      const sessionEmail = session.user.email ?? '';
+      const sessionName = session.user.name ?? '';
+
+      setIsLoading(true);
+      setErrorMessage(null);
+
+      try {
+        if (blogId) {
+          const response = await fetch(`/api/student/blogs/${blogId}`);
+          const payload = await response.json();
+
+          if (!response.ok) {
+            throw new Error(payload?.error || 'Failed to load blog post');
+          }
+
+          const blog = payload.data;
+          setFormData({
+            author: {
+              name: blog.author?.name ?? sessionName,
+              email: blog.author?.email ?? sessionEmail,
+              avatarUrl: blog.author?.avatarUrl ?? '',
+              instagram: blog.author?.instagram ?? '',
+              twitter: blog.author?.twitter ?? '',
+              facebook: blog.author?.facebook ?? '',
+              linkedin: blog.author?.linkedin ?? '',
+              medium: blog.author?.medium ?? '',
+              website: blog.author?.website ?? '',
+            },
+            post: {
+              title: blog.title ?? '',
+              excerpt: blog.excerpt ?? '',
+              content: blog.content ?? '',
+              imageUrl: blog.imageUrl ?? '',
+              category: blog.category ?? '',
+            },
+            approved: blog.approved ?? false,
+            rejectedById: blog.rejectedById ?? null,
+            rejectedReason: blog.rejectedReason ?? null,
+          });
+        } else {
+          const nextPayload = emptyPayload(sessionEmail, sessionName);
+
+          if (sessionEmail) {
+            const response = await fetch('/api/blogs/author/check', {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json',
+              },
+              body: JSON.stringify({ email: sessionEmail }),
+            });
+
+            if (response.ok) {
+              const author = await response.json();
+              nextPayload.author = {
+                name: author.name ?? sessionName,
+                email: author.email ?? sessionEmail,
+                avatarUrl: author.avatarUrl ?? '',
+                instagram: author.instagram ?? '',
+                twitter: author.twitter ?? '',
+                facebook: author.facebook ?? '',
+                linkedin: author.linkedin ?? '',
+                medium: author.medium ?? '',
+                website: author.website ?? '',
+              };
+            }
+          }
+
+          setFormData(nextPayload);
+        }
+      } catch (error) {
+        setErrorMessage(error instanceof Error ? error.message : 'Failed to load blog form');
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    void load();
+  }, [blogId, session?.user.email, session?.user.name, status]);
+
+  const updateAuthor = (key: keyof BlogPayload['author'], value: string) => {
+    setFormData((current) => ({
+      ...current,
+      author: {
+        ...current.author,
+        [key]: value,
+      },
+    }));
+  };
+
+  const updatePost = (key: keyof BlogPayload['post'], value: string) => {
+    setFormData((current) => ({
+      ...current,
+      post: {
+        ...current.post,
+        [key]: value,
+      },
+    }));
+  };
+
+  const handleUpload = async (kind: 'avatarUrl' | 'imageUrl', file: File) => {
+    try {
+      const url = await uploadImage(file);
+
+      if (kind === 'avatarUrl') {
+        updateAuthor('avatarUrl', url);
+      } else {
+        updatePost('imageUrl', url);
+      }
+
+      toast.success('Image uploaded');
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to upload image');
+    }
+  };
+
+  const handleSubmit = async () => {
+    setIsSaving(true);
+    setErrorMessage(null);
+    setFieldErrors({});
+
+    try {
+      const payload = {
+        author: formData.author,
+        post: {
+          ...formData.post,
+          category: formData.post.category as ProjectDomainEnum,
+          featured: false,
+        },
+      };
+
+      const validation = blogSubmissionSchema.safeParse(payload);
+      if (!validation.success) {
+        setFieldErrors(mapZodErrors(validation.error));
+        setIsSaving(false);
+        return;
+      }
+
+      const response = await fetch(blogId ? `/api/student/blogs/${blogId}` : '/api/student/blogs', {
+        method: blogId ? 'PATCH' : 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(payload),
+      });
+
+      const result = await response.json();
+      if (!response.ok) {
+        throw new Error(result?.error || 'Failed to save blog post');
+      }
+
+      toast.success(blogId ? 'Blog post updated' : 'Blog post created');
+      router.push('/student/blogs');
+      router.refresh();
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : 'Failed to save blog post');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className='space-y-4'>
+        <Skeleton className='h-10 w-full' />
+        <Skeleton className='h-32 w-full' />
+        <Skeleton className='h-80 w-full' />
+      </div>
+    );
+  }
+
+  if (errorMessage && !formData.author.email && !blogId) {
+    return (
+      <Alert variant='destructive'>
+        <AlertTitle>Error</AlertTitle>
+        <AlertDescription>{errorMessage}</AlertDescription>
+      </Alert>
+    );
+  }
+
+  return (
+    <div className='space-y-6'>
+      {blogId ? (
+        <div className='flex items-center gap-3'>
+          <BlogStatusBadge {...previewStatus} />
+          {formData.rejectedReason ? (
+            <p className='text-destructive text-sm'>Reason: {formData.rejectedReason}</p>
+          ) : null}
+        </div>
+      ) : null}
+
+      {errorMessage ? (
+        <Alert variant='destructive'>
+          <AlertTitle>Error</AlertTitle>
+          <AlertDescription>{errorMessage}</AlertDescription>
+        </Alert>
+      ) : null}
+
+      <div className='grid gap-6 xl:grid-cols-[1.2fr_0.8fr]'>
+        <div className='space-y-6'>
+          <section className='space-y-4 rounded-xl border p-5'>
+            <div>
+              <h2 className='text-xl font-semibold'>Author Profile</h2>
+              <p className='text-muted-foreground text-sm'>
+                This is linked to your student account email and will be reused across your posts.
+              </p>
+            </div>
+
+            <div className='grid gap-4 md:grid-cols-2'>
+              <div className='space-y-2'>
+                <Label>Email</Label>
+                <Input value={formData.author.email} readOnly />
+              </div>
+              <div className='space-y-2'>
+                <Label htmlFor='author-name'>Display Name</Label>
+                <Input
+                  id='author-name'
+                  value={formData.author.name}
+                  onChange={(event) => updateAuthor('name', event.target.value)}
+                />
+                {fieldErrors['author.name'] ? (
+                  <p className='text-destructive text-xs'>{fieldErrors['author.name']}</p>
+                ) : null}
+              </div>
+            </div>
+
+            <div className='space-y-2'>
+              <Label>Avatar</Label>
+              <div className='flex flex-wrap items-center gap-3'>
+                <Input
+                  value={formData.author.avatarUrl}
+                  onChange={(event) => updateAuthor('avatarUrl', event.target.value)}
+                  placeholder='https://...'
+                />
+                <Input
+                  type='file'
+                  accept='image/*'
+                  onChange={(event) => {
+                    const file = event.target.files?.[0];
+                    if (file) void handleUpload('avatarUrl', file);
+                  }}
+                  className='max-w-xs'
+                />
+              </div>
+              {formData.author.avatarUrl ? (
+                <img
+                  src={formData.author.avatarUrl}
+                  alt='Author avatar'
+                  className='h-16 w-16 rounded-full border object-cover'
+                />
+              ) : null}
+              {fieldErrors['author.avatarUrl'] ? (
+                <p className='text-destructive text-xs'>{fieldErrors['author.avatarUrl']}</p>
+              ) : null}
+            </div>
+
+            <div className='grid gap-4 md:grid-cols-2'>
+              {(['instagram', 'twitter', 'facebook', 'linkedin', 'medium', 'website'] as const).map((field) => (
+                <div key={field} className='space-y-2'>
+                  <Label className='capitalize'>{field}</Label>
+                  <Input
+                    value={formData.author[field]}
+                    onChange={(event) => updateAuthor(field, event.target.value)}
+                    placeholder={field === 'website' ? 'https://your-site.com' : `Your ${field} link`}
+                  />
+                  {fieldErrors[`author.${field}`] ? (
+                    <p className='text-destructive text-xs'>{fieldErrors[`author.${field}`]}</p>
+                  ) : null}
+                </div>
+              ))}
+            </div>
+          </section>
+
+          <section className='space-y-4 rounded-xl border p-5'>
+            <div>
+              <h2 className='text-xl font-semibold'>Post Details</h2>
+              <p className='text-muted-foreground text-sm'>
+                Rejected edits will be resubmitted for moderation automatically.
+              </p>
+            </div>
+
+            <div className='space-y-2'>
+              <Label htmlFor='blog-title'>Title</Label>
+              <Input
+                id='blog-title'
+                value={formData.post.title}
+                onChange={(event) => updatePost('title', event.target.value)}
+              />
+              {fieldErrors['post.title'] ? (
+                <p className='text-destructive text-xs'>{fieldErrors['post.title']}</p>
+              ) : null}
+            </div>
+
+            <div className='grid gap-4 md:grid-cols-2'>
+              <div className='space-y-2'>
+                <Label>Category</Label>
+                <select
+                  value={formData.post.category}
+                  onChange={(event) => updatePost('category', event.target.value)}
+                  className='border-input bg-background ring-offset-background flex h-10 w-full rounded-md border px-3 py-2 text-sm'
+                >
+                  <option value=''>Select a category</option>
+                  {categoryOptions.map((option) => (
+                    <option key={option} value={option}>
+                      {option}
+                    </option>
+                  ))}
+                </select>
+                {fieldErrors['post.category'] ? (
+                  <p className='text-destructive text-xs'>{fieldErrors['post.category']}</p>
+                ) : null}
+              </div>
+
+              <div className='space-y-2'>
+                <Label>Cover Image</Label>
+                <div className='flex flex-wrap items-center gap-3'>
+                  <Input
+                    value={formData.post.imageUrl}
+                    onChange={(event) => updatePost('imageUrl', event.target.value)}
+                    placeholder='https://...'
+                  />
+                  <Input
+                    type='file'
+                    accept='image/*'
+                    onChange={(event) => {
+                      const file = event.target.files?.[0];
+                      if (file) void handleUpload('imageUrl', file);
+                    }}
+                    className='max-w-xs'
+                  />
+                </div>
+                {fieldErrors['post.imageUrl'] ? (
+                  <p className='text-destructive text-xs'>{fieldErrors['post.imageUrl']}</p>
+                ) : null}
+              </div>
+            </div>
+
+            {formData.post.imageUrl ? (
+              <img
+                src={formData.post.imageUrl}
+                alt='Blog cover'
+                className='max-h-56 w-full rounded-lg border object-cover'
+              />
+            ) : null}
+
+            <div className='space-y-2'>
+              <Label htmlFor='blog-excerpt'>Excerpt</Label>
+              <Textarea
+                id='blog-excerpt'
+                value={formData.post.excerpt}
+                onChange={(event) => updatePost('excerpt', event.target.value)}
+                rows={4}
+              />
+              {fieldErrors['post.excerpt'] ? (
+                <p className='text-destructive text-xs'>{fieldErrors['post.excerpt']}</p>
+              ) : null}
+            </div>
+
+            <div className='space-y-2'>
+              <Label>Content</Label>
+              <MarkdownEditor
+                value={formData.post.content}
+                onChange={(value) => updatePost('content', value)}
+                placeholder='Write your blog post in Markdown...'
+                className='min-h-[360px]'
+              />
+              {fieldErrors['post.content'] ? (
+                <p className='text-destructive text-xs'>{fieldErrors['post.content']}</p>
+              ) : null}
+            </div>
+          </section>
+
+          <div className='flex flex-wrap gap-3'>
+            <Button onClick={() => void handleSubmit()} disabled={isSaving}>
+              {isSaving ? 'Saving...' : blogId ? 'Save Changes' : 'Create Blog Post'}
+            </Button>
+            <Button variant='outline' asChild>
+              <Link href='/student/blogs'>Cancel</Link>
+            </Button>
+          </div>
+        </div>
+
+        <aside className='space-y-4 rounded-xl border p-5'>
+          <div>
+            <h2 className='text-xl font-semibold'>Preview</h2>
+            <p className='text-muted-foreground text-sm'>
+              Check formatting before you submit it for moderation.
+            </p>
+          </div>
+
+          <div className='space-y-3'>
+            <div className='text-2xl font-semibold'>
+              {formData.post.title || 'Untitled draft'}
+            </div>
+            <div className='text-muted-foreground text-sm'>
+              {formData.post.excerpt || 'Your excerpt will appear here.'}
+            </div>
+            {formData.post.imageUrl ? (
+              <img
+                src={formData.post.imageUrl}
+                alt='Blog preview'
+                className='max-h-56 w-full rounded-lg border object-cover'
+              />
+            ) : null}
+          </div>
+
+          <div className='rounded-lg border p-4'>
+            <MarkdownPreview content={formData.post.content || '*Start writing to preview your post.*'} />
+          </div>
+        </aside>
+      </div>
+    </div>
+  );
+}

--- a/components/student/StudentBlogsClient.tsx
+++ b/components/student/StudentBlogsClient.tsx
@@ -1,0 +1,192 @@
+'use client';
+
+import Link from 'next/link';
+import { useCallback, useEffect, useState } from 'react';
+import { toast } from 'sonner';
+
+import { BlogStatusBadge, getBlogStatus } from '@/components/student/status-badges';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
+
+type BlogFilter = 'all' | 'pending' | 'approved' | 'rejected';
+
+type StudentBlogRow = {
+  id: string;
+  title: string;
+  excerpt: string;
+  approved: boolean;
+  rejectedById: string | null;
+  rejectedReason: string | null;
+  createdAt: string;
+};
+
+export default function StudentBlogsClient() {
+  const [filter, setFilter] = useState<BlogFilter>('all');
+  const [blogs, setBlogs] = useState<StudentBlogRow[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const loadBlogs = useCallback(async (status: BlogFilter) => {
+    setIsLoading(true);
+    setErrorMessage(null);
+
+    try {
+      const params = new URLSearchParams({
+        page: '1',
+        limit: '50',
+      });
+
+      if (status !== 'all') {
+        params.set('status', status);
+      }
+
+      const response = await fetch(`/api/student/blogs?${params.toString()}`);
+      const payload = await response.json();
+
+      if (!response.ok) {
+        throw new Error(payload?.error || 'Failed to load blog posts');
+      }
+
+      setBlogs(payload.data ?? []);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to load blog posts';
+      setErrorMessage(message);
+      setBlogs([]);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadBlogs(filter);
+  }, [filter, loadBlogs]);
+
+  const handleDelete = async (blogId: string) => {
+    if (!window.confirm('Delete this blog post?')) return;
+
+    try {
+      const response = await fetch(`/api/student/blogs/${blogId}`, {
+        method: 'DELETE',
+      });
+      const payload = await response.json();
+
+      if (!response.ok) {
+        throw new Error(payload?.error || 'Failed to delete blog post');
+      }
+
+      toast.success('Blog post deleted');
+      await loadBlogs(filter);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to delete blog post');
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className='space-y-3'>
+        <Skeleton className='h-9 w-80' />
+        <Skeleton className='h-10 w-full' />
+        <Skeleton className='h-10 w-full' />
+        <Skeleton className='h-10 w-full' />
+      </div>
+    );
+  }
+
+  if (errorMessage) {
+    return (
+      <Alert variant='destructive'>
+        <AlertTitle>Error</AlertTitle>
+        <AlertDescription>{errorMessage}</AlertDescription>
+      </Alert>
+    );
+  }
+
+  return (
+    <div className='space-y-4'>
+      <Tabs value={filter} onValueChange={(value) => setFilter(value as BlogFilter)}>
+        <TabsList>
+          <TabsTrigger value='all'>All</TabsTrigger>
+          <TabsTrigger value='pending'>Pending</TabsTrigger>
+          <TabsTrigger value='approved'>Approved</TabsTrigger>
+          <TabsTrigger value='rejected'>Rejected</TabsTrigger>
+        </TabsList>
+      </Tabs>
+
+      {blogs.length === 0 ? (
+        <Alert>
+          <AlertTitle>No blog posts yet</AlertTitle>
+          <AlertDescription>
+            Your blog submissions will appear here once you create them.
+          </AlertDescription>
+        </Alert>
+      ) : (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Title</TableHead>
+              <TableHead>Created</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead className='text-right'>Actions</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {blogs.map((blog) => {
+              const status = getBlogStatus(blog);
+              const isEditable = status !== 'approved';
+
+              return (
+                <TableRow key={blog.id}>
+                  <TableCell className='space-y-1'>
+                    <div className='font-medium'>{blog.title}</div>
+                    <div className='text-muted-foreground max-w-xl text-sm line-clamp-2'>
+                      {blog.excerpt}
+                    </div>
+                    {status === 'rejected' && blog.rejectedReason ? (
+                      <div className='text-destructive text-xs'>
+                        Reason: {blog.rejectedReason}
+                      </div>
+                    ) : null}
+                  </TableCell>
+                  <TableCell>{new Date(blog.createdAt).toLocaleDateString()}</TableCell>
+                  <TableCell>
+                    <BlogStatusBadge {...blog} />
+                  </TableCell>
+                  <TableCell className='text-right'>
+                    <div className='flex justify-end gap-2'>
+                      {status === 'approved' ? (
+                        <Button size='sm' variant='outline' asChild>
+                          <Link href={`/blog/${blog.id}`}>View</Link>
+                        </Button>
+                      ) : null}
+                      {isEditable ? (
+                        <Button size='sm' variant='outline' asChild>
+                          <Link href={`/student/blogs/${blog.id}/edit`}>Edit</Link>
+                        </Button>
+                      ) : (
+                        <Button size='sm' variant='outline' disabled>
+                          Edit
+                        </Button>
+                      )}
+                      {isEditable ? (
+                        <Button
+                          size='sm'
+                          variant='destructive'
+                          onClick={() => void handleDelete(blog.id)}
+                        >
+                          Delete
+                        </Button>
+                      ) : null}
+                    </div>
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      )}
+    </div>
+  );
+}

--- a/components/student/status-badges.tsx
+++ b/components/student/status-badges.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { ApprovalStatus } from '@/types/prisma-types';
+
+import { Badge } from '@/components/ui/badge';
+
+export function getBlogStatus(post: { approved: boolean; rejectedById?: string | null }) {
+  if (post.approved) return 'approved';
+  if (post.rejectedById) return 'rejected';
+  return 'pending';
+}
+
+export function BlogStatusBadge(post: { approved: boolean; rejectedById?: string | null }) {
+  const status = getBlogStatus(post);
+
+  if (status === 'approved') {
+    return <Badge>Approved</Badge>;
+  }
+
+  if (status === 'rejected') {
+    return <Badge variant='destructive'>Rejected</Badge>;
+  }
+
+  return <Badge variant='secondary'>Pending</Badge>;
+}
+
+export function AwardStatusBadge({ status }: { status: ApprovalStatus }) {
+  if (status === ApprovalStatus.APPROVED) {
+    return <Badge>Approved</Badge>;
+  }
+
+  if (status === ApprovalStatus.REJECTED) {
+    return <Badge variant='destructive'>Rejected</Badge>;
+  }
+
+  return <Badge variant='secondary'>Pending</Badge>;
+}

--- a/lib/student-dashboard/session.ts
+++ b/lib/student-dashboard/session.ts
@@ -1,0 +1,48 @@
+import { getServerSession } from "next-auth/next";
+import { NextResponse } from "next/server";
+
+import { authOptions } from "@/app/api/auth/[...nextauth]/route";
+import { Role } from "@/types/prisma-types";
+
+export type StudentSessionUser = {
+  id: string;
+  email: string;
+  name?: string | null;
+};
+
+type StudentSessionResult =
+  | { user: StudentSessionUser; response?: never }
+  | { user?: never; response: NextResponse };
+
+export async function getStudentSessionUser(): Promise<StudentSessionResult> {
+  const session = await getServerSession(authOptions);
+
+  if (!session?.user) {
+    return {
+      response: NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+    };
+  }
+
+  if (session.user.role !== Role.STUDENT) {
+    return {
+      response: NextResponse.json({ error: "Forbidden" }, { status: 403 }),
+    };
+  }
+
+  if (!session.user.id || !session.user.email) {
+    return {
+      response: NextResponse.json(
+        { error: "Student session is missing required identity fields" },
+        { status: 401 }
+      ),
+    };
+  }
+
+  return {
+    user: {
+      id: session.user.id,
+      email: session.user.email,
+      name: session.user.name,
+    },
+  };
+}

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -36,6 +36,7 @@ async function seedUsers() {
 
     await prisma.user.create({
         data: {
+            email: 'admin@sdgp.lk',
             role: 'ADMIN', 
             password: hashedPassword,
             name: 'Admin',

--- a/validations/award.ts
+++ b/validations/award.ts
@@ -5,10 +5,18 @@
 
 import { z } from 'zod';
 
-export const awardSubmissionSchema = z.object({
+const awardNameSchema = z
+  .string()
+  .min(1, 'Award name is required')
+  .max(25, 'Award name must be 25 words or less');
+
+const awardBaseSchema = z.object({
   projectId: z.string().min(1, 'Project is required'),
   competitionId: z.string().min(1, 'Competition is required'),
-  awardName: z.string().min(1, 'Award name is required').max(25, 'Award name must be 25 words or less'),
+  awardName: awardNameSchema,
+});
+
+export const awardSubmissionSchema = awardBaseSchema.extend({
   imageFile: z
     .instanceof(File)
     .refine((file) => ['image/jpeg', 'image/png'].includes(file.type), {
@@ -19,4 +27,9 @@ export const awardSubmissionSchema = z.object({
     }),
 });
 
+export const awardPayloadSchema = awardBaseSchema.extend({
+  image: z.string().url('Award image is required'),
+});
+
 export type AwardSubmissionInput = z.infer<typeof awardSubmissionSchema>;
+export type AwardPayloadInput = z.infer<typeof awardPayloadSchema>;


### PR DESCRIPTION
## What changed
- add student-only blog management pages, forms, and status tables in the dashboard
- add student-only award management pages, forms, and status tables in the dashboard
- add guarded student API routes for blog and award CRUD with ownership checks and moderation reset on resubmit
- fix admin user creation and seed data to satisfy the branch's required user email model

## Why
Issue #199 asks for student dashboard support to manage blogs and awards locally instead of sending students back to the public submission flows, with ownership enforced on the server and rejected edits resubmitted for moderation.

## Impact
- students can create, edit, and delete their own pending or rejected blogs from `/student/blogs`
- students can create, edit, and delete their own pending or rejected awards from `/student/awards`
- approved items remain read-only from the student dashboard
- the student dashboard now exposes direct navigation to both areas

Closes #199
