### PR TITLE
fix layout scroll & equal card heights in projects page 

### DIFF
--- a/app/(public)/project/page.tsx
+++ b/app/(public)/project/page.tsx
@@ -37,7 +37,6 @@ function ProjectsPageContent() {
     const [showMobileFilters, setShowMobileFilters] = useState(false);
     const [isInitialLoad, setIsInitialLoad] = useState(true);
     const [isFilterLoading, setIsFilterLoading] = useState(false);
-    const rightPanelRef = useRef<HTMLDivElement>(null);
 
     const currentParams = useMemo((): ProjectQueryParams => ({
         page: parseInt(searchParams.get('page') || '1', 10),
@@ -64,19 +63,6 @@ function ProjectsPageContent() {
             }
         }
     }, [isLoading, projects, isInitialLoad]);
-
-    // Intercept all wheel events and redirect to the right panel
-    useEffect(() => {
-        const handleWheel = (e: WheelEvent) => {
-            if (rightPanelRef.current) {
-                e.preventDefault();
-                rightPanelRef.current.scrollTop += e.deltaY;
-            }
-        };
-
-        document.addEventListener('wheel', handleWheel, { passive: false });
-        return () => document.removeEventListener('wheel', handleWheel);
-    }, []);
 
     const initialFilters = useMemo((): FilterState => ({
         featured: currentParams.featured || false,
@@ -165,7 +151,7 @@ function ProjectsPageContent() {
     useEffect(() => {
         const handleEscape = (e: KeyboardEvent) => {
             if (e.key === 'Escape' && showMobileFilters) {
-                // setShowMobileFilters(false);
+                setShowMobileFilters(false);
             }
         };
 
@@ -188,7 +174,7 @@ function ProjectsPageContent() {
     }
 
     return (
-        <div className="relative min-h-screen overflow-hidden">
+        <div className="relative min-h-screen">
             {/* Three.js starfield background — sits behind all content */}
             <ThreeScene />
 
@@ -199,15 +185,14 @@ function ProjectsPageContent() {
                         defaultTitle={currentParams.title ?? ""}
                         onSearch={handleSearch}
                     />
-
-                    <div className="flex flex-col md:flex-row gap-6 mt-8 md:h-[calc(100vh-12rem)]">
-                        {/* Desktop Filter Sidebar */}
-                        <div className="hidden md:block w-64 lg:w-72 flex-shrink-0 overflow-y-auto overscroll-contain">
+                    <div className="flex flex-col md:flex-row gap-6 mt-8">
+                        {/* Desktop Filter Sidebar — FIX: removed overflow-y-auto overscroll-contain */}
+                        <div className="hidden md:block w-64 lg:w-72 flex-shrink-0">
                             <FilterSidebar onFilterChange={handleFilterChange} initialFilters={initialFilters} />
                         </div>
 
-                        {/* Right panel — ref used to capture all wheel scroll */}
-                        <div ref={rightPanelRef} className="flex-1 overflow-y-auto overscroll-contain">
+                        {/* Right panel — FIX: removed ref, overflow-y-auto, overscroll-contain */}
+                        <div className="flex-1">
                             <ProjectExplorer
                                 currentParams={currentParams}
                                 projects={projects || []}

--- a/components/projects/filter-sidebar.tsx
+++ b/components/projects/filter-sidebar.tsx
@@ -476,7 +476,7 @@ export default function FilterSidebar({
 
   // --- JSX Rendering ---
   return (
-    <div className="bg-card p-3 rounded-lg border shadow-sm h-full flex flex-col">
+    <div className="bg-card p-3 rounded-lg border shadow-sm">
       {/* Header with Title and Clear Button */}
       <div className="flex justify-between items-center mb-3 pb-2 border-b">
         <h3 className="font-semibold text-base">Filters</h3>
@@ -508,7 +508,7 @@ export default function FilterSidebar({
       )}
 
       {/* Scrollable Filter Sections */}
-      <div className="space-y-1 divide-y divide-border/50 overflow-y-auto flex-grow">
+      <div className="space-y-1 divide-y divide-border/50">
         <FeaturedFilterSection
           selection={featuredOnly}
           setSelection={setFeaturedOnly}

--- a/components/projects/project-explorer.tsx
+++ b/components/projects/project-explorer.tsx
@@ -40,7 +40,7 @@ export default function ProjectExplorer({
     const sentinel = sentinelRef.current;
     if (!sentinel) return;
 
-    const scrollRoot = sentinel.closest<HTMLElement>('.overflow-y-auto');
+    // root: null targets the viewport, which is correct now that the page scrolls naturally
 
     const observer = new IntersectionObserver(
       (entries) => {
@@ -56,7 +56,7 @@ export default function ProjectExplorer({
           onPageChange((meta.currentPage || 1) + 1);
         }
       },
-      { threshold: 0.1, root: scrollRoot ?? null }
+      { threshold: 0.1, root: null }
     );
 
     observer.observe(sentinel);
@@ -84,7 +84,7 @@ export default function ProjectExplorer({
 
   if (isFilterLoading) {
     return (
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 items-stretch">
         {Array(currentParams.limit || 9)
           .fill(0)
           .map((_, i) => (
@@ -96,7 +96,7 @@ export default function ProjectExplorer({
 
   if (isLoading && (!projects || projects.length === 0)) {
     return (
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 items-stretch">
         {Array(currentParams.limit || 9)
           .fill(0)
           .map((_, i) => (
@@ -120,15 +120,15 @@ export default function ProjectExplorer({
 
   return (
     <div className="flex flex-col gap-8">
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 items-stretch">
         {projects.map((project) => {
           return (
-            <div key={project.id} className="project-card-container">
+            <div key={project.id} className="h-full">
               <Link
                 href={`/project/${project.id}`}
-                className="project-card group block rounded-xl overflow-hidden border bg-card shadow-sm hover:shadow-lg transition-all duration-300 ease-in-out"
+                className="project-card group flex flex-col h-full rounded-xl overflow-hidden border bg-card shadow-sm hover:shadow-lg transition-all duration-300 ease-in-out"
               >
-                <div className="relative aspect-video overflow-hidden">
+                <div className="relative aspect-video overflow-hidden flex-shrink-0">
                   <Image
                     src={
                       project.coverImage ||
@@ -146,7 +146,7 @@ export default function ProjectExplorer({
                   )}
                 </div>
 
-                <div className="p-4 flex flex-col h-[calc(100%-aspect-video)]">
+                <div className="p-4 flex flex-col flex-1">
                   <h3 className="text-lg font-semibold mb-1 line-clamp-1">
                     {project.title}
                   </h3>
@@ -215,7 +215,7 @@ export default function ProjectExplorer({
       </div>
 
       {isLoading && projects.length > 0 && (
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 items-stretch">
           {Array(3)
             .fill(0)
             .map((_, i) => (


### PR DESCRIPTION
<img width="384" height="746" alt="image" src="https://github.com/user-attachments/assets/b5f98157-aee1-4a76-bb7d-3a0afce161de" />

<img width="1468" height="882" alt="image" src="https://github.com/user-attachments/assets/faba24a1-f80d-477e-8d9b-a639f9c9d541" />





- Remove wheel-hijack useEffect and rightPanelRef from page.tsx so
  sidebar and project grid scroll together as one page instead of
  independently

- Remove md:h-[calc(100vh-12rem)] fixed height and overflow-y-auto
  from the flex row, sidebar wrapper, and right panel div so all
  columns participate in normal page flow

- Remove h-full flex flex-col from FilterSidebar root and
  overflow-y-auto flex-grow from its sections wrapper so the sidebar
  takes natural height

- Fix broken h-[calc(100%-aspect-video)] on card content div by
  replacing with flex-1; change card Link from block to flex flex-col
  h-full and add h-full to the wrapper div so all cards in a row
  stretch to equal height

- Add flex-shrink-0 to the aspect-video image wrapper so the image
  never collapses under flex pressure

- Add items-stretch to all three grid divs (main, filter skeleton,
  load-more skeleton) to enforce equal row heights

- Fix IntersectionObserver scrollRoot lookup (removed .overflow-y-auto
  ancestor search) and set root: null so infinite scroll targets the
  viewport correctly after the layout change

- Fix Escape key handler in mobile filter overlay that was accidentally
  commented out