### PR TITLE
feat: chatbot AI + db filtering architecture

### DIFF
--- a/app/(public)/layout.tsx
+++ b/app/(public)/layout.tsx
@@ -72,12 +72,13 @@ export default function RootLayout({
           rel="stylesheet"
           href="https://fonts.googleapis.com/css2?family=Geist:wght@400;700&display=swap"
         />
+        {/* Preload the Geist Mono font
         <script
           defer
           src="https://api.psycodelabs.lk/widget.js"
           data-key="pk_b3a99bccdb1c43c3d49599b7f2ad4fa3857306cd7cce0b2f"
           data-api="https://api.psycodelabs.lk"
-        ></script>
+        ></script>  */}
 
       </head>
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>

--- a/app/(public)/layout.tsx
+++ b/app/(public)/layout.tsx
@@ -72,7 +72,7 @@ export default function RootLayout({
           rel="stylesheet"
           href="https://fonts.googleapis.com/css2?family=Geist:wght@400;700&display=swap"
         />
-        {/* Preload the Geist Mono font
+        {/* temporarily removing third-party AI chatbot
         <script
           defer
           src="https://api.psycodelabs.lk/widget.js"

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -84,10 +84,10 @@ function getRetryAfterMinutes(err: unknown): number | null {
   return Math.ceil(seconds / 60);
 }
 
-async function withRetry<T>(fn: () => Promise<T>, retries = 3): Promise<T> {
+async function withRetry<T>(fn: (attempt: number) => Promise<T>, retries = 3): Promise<T> {
   for (let attempt = 0; ; attempt++) {
     try {
-      return await fn();
+      return await fn(attempt);
     } catch (err) {
       if (isDailyQuotaExceeded(err)) {
         const mins = getRetryAfterMinutes(err);
@@ -133,12 +133,15 @@ export async function POST(req: NextRequest) {
     ];
 
     for (let turn = 0; turn < 4; turn++) {
-      const response = await withRetry(() =>
+      const response = await withRetry((attempt) =>
         groq.chat.completions.create({
           model: MODEL,
           messages: chatMessages,
           tools,
           temperature: 0.2,
+          ...(attempt > 0
+            ? { tool_choice: { type: "function", function: { name: "search_projects" } } as const }
+            : {}),
         })
       );
 
@@ -156,15 +159,30 @@ export async function POST(req: NextRequest) {
 
       for (const call of toolCalls) {
         if (call.function.name === "search_projects") {
-          let args: ProjectSearchParams = {};
+          let args: ProjectSearchParams | null = null;
           try {
             const parsed = call.function.arguments
               ? JSON.parse(call.function.arguments)
-              : null;
+              : {};
             if (parsed && typeof parsed === "object") args = parsed;
           } catch {
-            // malformed JSON from the model — fall back to an unfiltered search
+            console.warn(
+              "search_projects: malformed tool-call arguments from model:",
+              call.function.arguments
+            );
           }
+
+          if (args === null) {
+            chatMessages.push({
+              role: "tool",
+              tool_call_id: call.id,
+              content: JSON.stringify({
+                error: "Invalid arguments: could not parse as JSON. Retry the call with valid JSON arguments.",
+              }),
+            });
+            continue;
+          }
+
           console.log("search_projects called with:", args);
           const results = await searchProjects(args);
           chatMessages.push({
@@ -181,7 +199,12 @@ export async function POST(req: NextRequest) {
     const { status, error } = toGroqErrorShape(err);
     const code = error?.error?.code;
     if (!(status === 429 && isDailyQuotaExceeded(err))) {
-      console.error("Chat API error:", err);
+      console.error(
+        "Chat API error:",
+        status ?? "no-status",
+        code ?? "no-code",
+        error?.error?.message ?? (err instanceof Error ? err.message : String(err))
+      );
     }
 
     if (status === 429) {

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,0 +1,127 @@
+import Groq from "groq-sdk";
+import { NextRequest, NextResponse } from "next/server";
+import { searchProjects, ProjectSearchParams } from "@/lib/projectSearch";
+
+const groq = new Groq({ apiKey: process.env.GROQ_API_KEY });
+
+const MODEL = "llama-3.3-70b-versatile";
+
+const SYSTEM_PROMPT = `You are the assistant embedded on SDGP.lk, a directory of student software/hardware projects (AI, ML, healthtech, fintech, edtech, and more).
+
+Rules:
+- For any question about specific projects, teams, domains, tech stacks, SDG goals, or "best/featured" projects, ALWAYS call the search_projects tool first. Never invent project details.
+- If the tool returns no results, say so plainly and don't make something up.
+- For open-ended or advice questions (e.g. "what AI or medical project should I build?"), you may combine real examples from search_projects with your own general knowledge to suggest ideas — but clearly distinguish "here's what's already on SDGP.lk" from "here's an idea you could build."
+- Keep answers concise and link to the project's website field when available.
+- Never reveal internal fields like emails, phone numbers, or unapproved/pending projects — the tool already filters these out, so just don't speculate beyond what it returns.`;
+
+const tools: Groq.Chat.Completions.ChatCompletionTool[] = [
+  {
+    type: "function",
+    function: {
+      name: "search_projects",
+      description:
+        "Search approved student projects on SDGP.lk by keyword, domain, tech stack, SDG goal, project type, status, or featured flag.",
+      parameters: {
+        type: "object",
+        properties: {
+          keyword: { type: "string", description: "Free-text search on project title/subtitle" },
+          domain: {
+            type: "string",
+            enum: [
+              "AI", "ML", "AR_VR", "BLOCKCHAIN", "IOT", "HEALTHTECH", "FINTECH",
+              "EDTECH", "AGRITECH", "ECOMMERCE", "SOCIAL", "GAMING", "SECURITY",
+              "DATA_ANALYTICS", "ENTERTAINMENT", "SUSTAINABILITY",
+            ],
+          },
+          techStack: { type: "string", description: "One of the TechStackEnum values, e.g. REACT, PYTHON, TENSORFLOW" },
+          projectType: { type: "string", enum: ["MOBILE", "WEB", "HARDWARE", "DESKTOP", "WEARABLE", "EXTENSION"] },
+          sdgGoal: { type: "string", description: "One of the SDGGoalEnum values, e.g. GOOD_HEALTH, CLIMATE_ACTION" },
+          status: { type: "string", enum: ["IDEA", "MVP", "RESEARCH", "DEPLOYED", "STARTUP"] },
+          featuredOnly: { type: "boolean", description: "Set true when the user asks for 'best' or 'featured' projects" },
+          limit: { type: "number", description: "Max results, default 5, max 10" },
+        },
+      },
+    },
+  },
+];
+
+type ChatMessage = { role: "user" | "assistant"; content: string };
+
+async function withRetry<T>(fn: () => Promise<T>, retries = 2): Promise<T> {
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      const status = (err as { status?: number })?.status;
+      const isTransient = status === 503 || status === 429;
+      if (!isTransient || attempt >= retries) throw err;
+      await new Promise((r) => setTimeout(r, 500 * 2 ** attempt));
+    }
+  }
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const { messages } = await req.json();
+
+    if (!Array.isArray(messages) || messages.length === 0) {
+      return NextResponse.json({ error: "messages array is required" }, { status: 400 });
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const chatMessages: any[] = [
+      { role: "system", content: SYSTEM_PROMPT },
+      ...messages.map((m: ChatMessage) => ({ role: m.role, content: m.content })),
+    ];
+
+    for (let turn = 0; turn < 4; turn++) {
+      const response = await withRetry(() =>
+        groq.chat.completions.create({
+          model: MODEL,
+          messages: chatMessages,
+          tools,
+        })
+      );
+
+      const choice = response.choices[0];
+      const toolCalls = choice.message.tool_calls;
+
+      if (!toolCalls || toolCalls.length === 0) {
+        return NextResponse.json({ reply: choice.message.content ?? "" });
+      }
+
+      chatMessages.push(choice.message);
+
+      for (const call of toolCalls) {
+        if (call.function.name === "search_projects") {
+          const args = JSON.parse(call.function.arguments) as ProjectSearchParams;
+          const results = await searchProjects(args);
+          chatMessages.push({
+            role: "tool",
+            tool_call_id: call.id,
+            content: JSON.stringify(results),
+          });
+        }
+      }
+    }
+
+    return NextResponse.json({ reply: "Sorry, I couldn't complete that request." });
+  } catch (err) {
+    console.error("Chat API error:", err);
+    const status = (err as { status?: number })?.status;
+    if (status === 429) {
+      return NextResponse.json(
+        { reply: "I'm getting a lot of questions right now and hit today's free usage limit. Please try again in a bit." },
+        { status: 200 }
+      );
+    }
+    if (status === 503) {
+      return NextResponse.json(
+        { reply: "The AI service is overloaded right now. Please try again in a moment." },
+        { status: 200 }
+      );
+    }
+    return NextResponse.json({ error: "Something went wrong." }, { status: 500 });
+  }
+}

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -4,7 +4,7 @@ import { searchProjects, ProjectSearchParams } from "@/lib/projectSearch";
 
 const groq = new Groq({ apiKey: process.env.GROQ_API_KEY });
 
-const MODEL = "llama-3.3-70b-versatile";
+const MODEL = "openai/gpt-oss-120b";
 
 let quotaResetAt: number | null = null;
 

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -6,13 +6,18 @@ const groq = new Groq({ apiKey: process.env.GROQ_API_KEY });
 
 const MODEL = "llama-3.3-70b-versatile";
 
+let quotaResetAt: number | null = null;
+
 const SYSTEM_PROMPT = `You are the assistant embedded on SDGP.lk, a directory of student software/hardware projects (AI, ML, healthtech, fintech, edtech, and more).
 
 Rules:
 - For any question about specific projects, teams, domains, tech stacks, SDG goals, or "best/featured" projects, ALWAYS call the search_projects tool first. Never invent project details.
 - If the tool returns no results, say so plainly and don't make something up.
-- For open-ended or advice questions (e.g. "what AI or medical project should I build?"), you may combine real examples from search_projects with your own general knowledge to suggest ideas — but clearly distinguish "here's what's already on SDGP.lk" from "here's an idea you could build."
-- Keep answers concise and link to the project's website field when available.
+- If the user asks for an idea, inspiration, or "what should I build" (rather than asking about existing projects), you MUST do two things, in this order:
+  1. Call search_projects and list 1-3 relevant existing projects under a heading like "Similar projects already on SDGP.lk", each with its View Project link — for context/inspiration only.
+  2. Then propose at least one genuinely NEW idea, under a heading like "An idea you could build", that is NOT one of the projects returned by search_projects. Base it on gaps you notice in the search results or general domain knowledge, and describe it in 2-3 sentences.
+  Never present an existing project as if it were a suggestion for the user to go build.
+- Keep answers concise. For each project you mention, write its title as plain text (do NOT turn the title itself into a markdown link), then include a separate "View Project" link using its pageUrl field, e.g.: "BlynQ. — An AI Powered Vehicle Management System. [View Project](pageUrl)". Never use the website field, and never link the same pageUrl twice in one line.
 - Never reveal internal fields like emails, phone numbers, or unapproved/pending projects — the tool already filters these out, so just don't speculate beyond what it returns.`;
 
 const tools: Groq.Chat.Completions.ChatCompletionTool[] = [
@@ -39,7 +44,7 @@ const tools: Groq.Chat.Completions.ChatCompletionTool[] = [
           sdgGoal: { type: "string", description: "One of the SDGGoalEnum values, e.g. GOOD_HEALTH, CLIMATE_ACTION" },
           status: { type: "string", enum: ["IDEA", "MVP", "RESEARCH", "DEPLOYED", "STARTUP"] },
           featuredOnly: { type: "boolean", description: "Set true when the user asks for 'best' or 'featured' projects" },
-          limit: { type: "number", description: "Max results, default 5, max 10" },
+          limit: { type: "number", description: "Max results, default 3, max 8" },
         },
       },
     },
@@ -48,15 +53,54 @@ const tools: Groq.Chat.Completions.ChatCompletionTool[] = [
 
 type ChatMessage = { role: "user" | "assistant"; content: string };
 
-async function withRetry<T>(fn: () => Promise<T>, retries = 2): Promise<T> {
+interface GroqErrorShape {
+  status?: number;
+  headers?: Headers;
+  error?: {
+    error?: {
+      code?: string;
+      message?: string;
+      type?: string;
+    };
+  };
+}
+
+function toGroqErrorShape(err: unknown): GroqErrorShape {
+  return typeof err === "object" && err !== null ? (err as GroqErrorShape) : {};
+}
+
+function isDailyQuotaExceeded(err: unknown): boolean {
+  const { error } = toGroqErrorShape(err);
+  const message = error?.error?.message ?? "";
+  return error?.error?.type === "tokens" && /tokens per day|TPD/i.test(message);
+}
+
+function getRetryAfterMinutes(err: unknown): number | null {
+  const { headers } = toGroqErrorShape(err);
+  const raw = headers?.get?.("retry-after");
+  if (!raw) return null;
+  const seconds = Number(raw);
+  if (Number.isNaN(seconds)) return null;
+  return Math.ceil(seconds / 60);
+}
+
+async function withRetry<T>(fn: () => Promise<T>, retries = 3): Promise<T> {
   for (let attempt = 0; ; attempt++) {
     try {
       return await fn();
     } catch (err) {
-      const status = (err as { status?: number })?.status;
-      const isTransient = status === 503 || status === 429;
+      if (isDailyQuotaExceeded(err)) {
+        const mins = getRetryAfterMinutes(err);
+        if (mins) quotaResetAt = Date.now() + mins * 60_000;
+        console.warn(`[groq] daily token quota exhausted, resets in ~${mins ?? "?"} min`);
+        throw err;
+      }
+
+      const { status, error } = toGroqErrorShape(err);
+      const code = error?.error?.code;
+      const isTransient = status === 503 || status === 429 || code === "tool_use_failed";
       if (!isTransient || attempt >= retries) throw err;
-      await new Promise((r) => setTimeout(r, 500 * 2 ** attempt));
+      await new Promise((r) => setTimeout(r, 400 * 2 ** attempt));
     }
   }
 }
@@ -69,10 +113,23 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: "messages array is required" }, { status: 400 });
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const chatMessages: any[] = [
+    if (quotaResetAt && Date.now() < quotaResetAt) {
+      const mins = Math.ceil((quotaResetAt - Date.now()) / 60_000);
+      return NextResponse.json(
+        {
+          reply: `I've hit today's usage limit. Please try again in about ${mins} minute${mins === 1 ? "" : "s"}.`,
+        },
+        { status: 200 }
+      );
+    }
+
+    type GroqMessage = Groq.Chat.Completions.ChatCompletionMessageParam;
+    const MAX_HISTORY_MESSAGES = 8;
+    const trimmedMessages = messages.slice(-MAX_HISTORY_MESSAGES);
+
+    const chatMessages: GroqMessage[] = [
       { role: "system", content: SYSTEM_PROMPT },
-      ...messages.map((m: ChatMessage) => ({ role: m.role, content: m.content })),
+      ...trimmedMessages.map((m: ChatMessage) => ({ role: m.role, content: m.content })),
     ];
 
     for (let turn = 0; turn < 4; turn++) {
@@ -81,10 +138,14 @@ export async function POST(req: NextRequest) {
           model: MODEL,
           messages: chatMessages,
           tools,
+          temperature: 0.2,
         })
       );
 
       const choice = response.choices[0];
+      console.log(
+        `[groq usage] turn ${turn} — prompt: ${response.usage?.prompt_tokens}, completion: ${response.usage?.completion_tokens}, total: ${response.usage?.total_tokens}`
+      );
       const toolCalls = choice.message.tool_calls;
 
       if (!toolCalls || toolCalls.length === 0) {
@@ -95,7 +156,16 @@ export async function POST(req: NextRequest) {
 
       for (const call of toolCalls) {
         if (call.function.name === "search_projects") {
-          const args = JSON.parse(call.function.arguments) as ProjectSearchParams;
+          let args: ProjectSearchParams = {};
+          try {
+            const parsed = call.function.arguments
+              ? JSON.parse(call.function.arguments)
+              : null;
+            if (parsed && typeof parsed === "object") args = parsed;
+          } catch {
+            // malformed JSON from the model — fall back to an unfiltered search
+          }
+          console.log("search_projects called with:", args);
           const results = await searchProjects(args);
           chatMessages.push({
             role: "tool",
@@ -108,17 +178,38 @@ export async function POST(req: NextRequest) {
 
     return NextResponse.json({ reply: "Sorry, I couldn't complete that request." });
   } catch (err) {
-    console.error("Chat API error:", err);
-    const status = (err as { status?: number })?.status;
+    const { status, error } = toGroqErrorShape(err);
+    const code = error?.error?.code;
+    if (!(status === 429 && isDailyQuotaExceeded(err))) {
+      console.error("Chat API error:", err);
+    }
+
     if (status === 429) {
+      if (isDailyQuotaExceeded(err)) {
+        const mins = getRetryAfterMinutes(err);
+        return NextResponse.json(
+          {
+            reply: mins
+              ? `I've hit today's usage limit. Please try again in about ${mins} minute${mins === 1 ? "" : "s"}.`
+              : "I've hit today's usage limit. Please try again later.",
+          },
+          { status: 200 }
+        );
+      }
       return NextResponse.json(
-        { reply: "I'm getting a lot of questions right now and hit today's free usage limit. Please try again in a bit." },
+        { reply: "I'm getting a lot of questions right now. Please try again in a bit." },
         { status: 200 }
       );
     }
     if (status === 503) {
       return NextResponse.json(
         { reply: "The AI service is overloaded right now. Please try again in a moment." },
+        { status: 200 }
+      );
+    }
+    if (code === "tool_use_failed") {
+      return NextResponse.json(
+        { reply: "I had trouble processing that — could you rephrase your question?" },
         { status: 200 }
       );
     }

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,3 +1,8 @@
+// © 2026 SDGP.lk
+// Licensed under the GNU Affero General Public License v3.0 or later,
+// with an additional restriction: Non-commercial use only.
+// See <https://www.gnu.org/licenses/agpl-3.0.html> for details.
+
 import Groq from "groq-sdk";
 import { NextRequest, NextResponse } from "next/server";
 import { searchProjects, ProjectSearchParams } from "@/lib/projectSearch";

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -6,24 +6,17 @@
 import Groq from "groq-sdk";
 import { NextRequest, NextResponse } from "next/server";
 import { searchProjects, ProjectSearchParams } from "@/lib/projectSearch";
-
-const groq = new Groq({ apiKey: process.env.GROQ_API_KEY });
-
-const MODEL = "openai/gpt-oss-120b";
+import {
+  groq,
+  MODEL,
+  SYSTEM_PROMPT,
+  MAX_HISTORY_MESSAGES,
+  MAX_MESSAGES,
+  MAX_MESSAGE_LENGTH,
+  QUOTA_EXCEEDED_MESSAGE,
+} from "@/lib/constants/groq";
 
 let quotaResetAt: number | null = null;
-
-const SYSTEM_PROMPT = `You are the assistant embedded on SDGP.lk, a directory of student software/hardware projects (AI, ML, healthtech, fintech, edtech, and more).
-
-Rules:
-- For any question about specific projects, teams, domains, tech stacks, SDG goals, or "best/featured" projects, ALWAYS call the search_projects tool first. Never invent project details.
-- If the tool returns no results, say so plainly and don't make something up.
-- If the user asks for an idea, inspiration, or "what should I build" (rather than asking about existing projects), you MUST do two things, in this order:
-  1. Call search_projects and list 1-3 relevant existing projects under a heading like "Similar projects already on SDGP.lk", each with its View Project link — for context/inspiration only.
-  2. Then propose at least one genuinely NEW idea, under a heading like "An idea you could build", that is NOT one of the projects returned by search_projects. Base it on gaps you notice in the search results or general domain knowledge, and describe it in 2-3 sentences.
-  Never present an existing project as if it were a suggestion for the user to go build.
-- Keep answers concise. For each project you mention, write its title as plain text (do NOT turn the title itself into a markdown link), then include a separate "View Project" link using its pageUrl field, e.g.: "BlynQ. — An AI Powered Vehicle Management System. [View Project](pageUrl)". Never use the website field, and never link the same pageUrl twice in one line.
-- Never reveal internal fields like emails, phone numbers, or unapproved/pending projects — the tool already filters these out, so just don't speculate beyond what it returns.`;
 
 const tools: Groq.Chat.Completions.ChatCompletionTool[] = [
   {
@@ -57,6 +50,17 @@ const tools: Groq.Chat.Completions.ChatCompletionTool[] = [
 ];
 
 type ChatMessage = { role: "user" | "assistant"; content: string };
+
+function isValidChatMessage(m: unknown): m is ChatMessage {
+  if (typeof m !== "object" || m === null) return false;
+  const { role, content } = m as Record<string, unknown>;
+  return (
+    (role === "user" || role === "assistant") &&
+    typeof content === "string" &&
+    content.trim().length > 0 &&
+    content.length <= MAX_MESSAGE_LENGTH
+  );
+}
 
 interface GroqErrorShape {
   status?: number;
@@ -112,29 +116,42 @@ async function withRetry<T>(fn: (attempt: number) => Promise<T>, retries = 3): P
 
 export async function POST(req: NextRequest) {
   try {
-    const { messages } = await req.json();
+    let body: unknown;
+    try {
+      body = await req.json();
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+    }
+
+    const { messages } = (body ?? {}) as { messages?: unknown };
 
     if (!Array.isArray(messages) || messages.length === 0) {
       return NextResponse.json({ error: "messages array is required" }, { status: 400 });
     }
 
-    if (quotaResetAt && Date.now() < quotaResetAt) {
-      const mins = Math.ceil((quotaResetAt - Date.now()) / 60_000);
+    if (messages.length > MAX_MESSAGES) {
+      return NextResponse.json({ error: "Too many messages." }, { status: 400 });
+    }
+
+    if (!messages.every(isValidChatMessage)) {
       return NextResponse.json(
-        {
-          reply: `I've hit today's usage limit. Please try again in about ${mins} minute${mins === 1 ? "" : "s"}.`,
-        },
-        { status: 200 }
+        { error: "Each message must have a role of 'user' or 'assistant' and non-empty string content." },
+        { status: 400 }
       );
     }
 
+    if (quotaResetAt && Date.now() < quotaResetAt) {
+      const mins = Math.ceil((quotaResetAt - Date.now()) / 60_000);
+      console.warn(`[groq] blocked request, daily quota resets in ~${mins} min`);
+      return NextResponse.json({ reply: QUOTA_EXCEEDED_MESSAGE }, { status: 200 });
+    }
+
     type GroqMessage = Groq.Chat.Completions.ChatCompletionMessageParam;
-    const MAX_HISTORY_MESSAGES = 8;
-    const trimmedMessages = messages.slice(-MAX_HISTORY_MESSAGES);
+    const trimmedMessages = (messages as ChatMessage[]).slice(-MAX_HISTORY_MESSAGES);
 
     const chatMessages: GroqMessage[] = [
       { role: "system", content: SYSTEM_PROMPT },
-      ...trimmedMessages.map((m: ChatMessage) => ({ role: m.role, content: m.content })),
+      ...trimmedMessages.map((m) => ({ role: m.role, content: m.content })),
     ];
 
     for (let turn = 0; turn < 4; turn++) {
@@ -215,14 +232,8 @@ export async function POST(req: NextRequest) {
     if (status === 429) {
       if (isDailyQuotaExceeded(err)) {
         const mins = getRetryAfterMinutes(err);
-        return NextResponse.json(
-          {
-            reply: mins
-              ? `I've hit today's usage limit. Please try again in about ${mins} minute${mins === 1 ? "" : "s"}.`
-              : "I've hit today's usage limit. Please try again later.",
-          },
-          { status: 200 }
-        );
+        console.warn(`[groq] daily quota exceeded, resets in ~${mins ?? "?"} min`);
+        return NextResponse.json({ reply: QUOTA_EXCEEDED_MESSAGE }, { status: 200 });
       }
       return NextResponse.json(
         { reply: "I'm getting a lot of questions right now. Please try again in a bit." },

--- a/components/ChatBot.tsx
+++ b/components/ChatBot.tsx
@@ -1,0 +1,335 @@
+"use client";
+
+import { useState, useRef, useEffect } from "react";
+import { createPortal } from "react-dom";
+import Image from "next/image";
+import ReactMarkdown from "react-markdown";
+
+type Message = { role: "user" | "assistant"; content: string };
+
+const STARTER_PROMPTS = [
+  "Show me featured AI projects",
+  "What healthtech projects exist?",
+  "Suggest an AI project idea",
+];
+
+const LOGO_SRC = "/iconw.svg";
+
+function BotIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" className={className}>
+      <rect x="4" y="8" width="16" height="12" rx="4" stroke="currentColor" strokeWidth="1.5" />
+      <path d="M12 8V5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+      <circle cx="12" cy="3.5" r="1.5" fill="currentColor" />
+      <circle cx="9" cy="14" r="1.3" fill="currentColor" />
+      <circle cx="15" cy="14" r="1.3" fill="currentColor" />
+      <path d="M2 13h2M20 13h2" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+function ShieldCheckIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" className={className}>
+      <path
+        d="M12 3l7 3v5c0 4.5-3 8-7 10-4-2-7-5.5-7-10V6l7-3z"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinejoin="round"
+      />
+      <path d="M9 12l2 2 4-4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+function RefreshIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" className={className}>
+      <path
+        d="M4 4v5h5M20 20v-5h-5"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M4.5 15a8 8 0 0014.5 3.5M19.5 9A8 8 0 005 5.5"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function XIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" className={className}>
+      <path d="M6 6l12 12M18 6L6 18" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+function SendIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" className={className}>
+      <path
+        d="M4 12l16-7-6 16-2.5-6.5L4 12z"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinejoin="round"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}
+
+function greetingForTime() {
+  const hour = new Date().getHours();
+  if (hour < 12) return "Good morning";
+  if (hour < 18) return "Good afternoon";
+  return "Good evening";
+}
+
+const CONSENT_KEY = "sdgp_chat_consent";
+const TOOLTIP_KEY = "sdgp_chat_tooltip_dismissed";
+const MAX_LEN = 200;
+
+export default function ChatBot() {
+  const [mounted, setMounted] = useState(false);
+  const [open, setOpen] = useState(false);
+  const [consented, setConsented] = useState(false);
+  const [showTooltip, setShowTooltip] = useState(false);
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [input, setInput] = useState("");
+  const [loading, setLoading] = useState(false);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    setMounted(true);
+    setConsented(localStorage.getItem(CONSENT_KEY) === "true");
+    setShowTooltip(localStorage.getItem(TOOLTIP_KEY) !== "true");
+  }, []);
+
+  useEffect(() => {
+    scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: "smooth" });
+  }, [messages, loading]);
+
+  function acceptConsent() {
+    localStorage.setItem(CONSENT_KEY, "true");
+    setConsented(true);
+  }
+
+  function dismissTooltip() {
+    localStorage.setItem(TOOLTIP_KEY, "true");
+    setShowTooltip(false);
+  }
+
+  function resetChat() {
+    setMessages([]);
+    setInput("");
+  }
+
+  async function send(text: string) {
+    if (!text.trim() || loading) return;
+    dismissTooltip();
+    const next: Message[] = [...messages, { role: "user", content: text }];
+    setMessages(next);
+    setInput("");
+    setLoading(true);
+
+    try {
+      const res = await fetch("/api/chat", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ messages: next }),
+      });
+      const data = await res.json();
+      setMessages([...next, { role: "assistant", content: data.reply ?? "Something went wrong." }]);
+    } catch {
+      setMessages([...next, { role: "assistant", content: "Couldn't reach the server. Try again in a moment." }]);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  if (!mounted) return null;
+
+  return createPortal(
+    <div className="fixed bottom-0 right-0 z-[9999] flex flex-col items-end font-sans sm:bottom-5 sm:right-5">
+      {open && (
+        <div className="fixed inset-0 z-[9999] flex h-[100dvh] w-screen flex-col overflow-hidden bg-black text-white sm:static sm:z-auto sm:mb-3 sm:h-[min(600px,calc(100dvh-6rem))] sm:w-[380px] sm:rounded-3xl sm:border sm:border-white/10 sm:shadow-2xl sm:shadow-black/40">
+          <div className="flex items-center justify-between border-b border-white/10 px-4 py-3.5">
+            <div className="flex items-center gap-3">
+              <div className="flex h-9 w-9 items-center justify-center overflow-hidden rounded-xl border border-white/10 bg-white/5">
+                <Image
+                  src={LOGO_SRC}
+                  alt="Logo"
+                  width={22}
+                  height={22}
+                  onError={(e) => (e.currentTarget.style.display = "none")}
+                />
+              </div>
+              <div>
+                <p className="text-sm font-semibold leading-tight">Assistant</p>
+                <p className="flex items-center gap-1.5 text-xs text-white/50">
+                  <span className="h-1.5 w-1.5 rounded-full bg-emerald-400" />
+                  Online
+                </p>
+              </div>
+            </div>
+            <button
+              onClick={resetChat}
+              aria-label="Restart chat"
+              className="rounded-full p-1.5 text-white/50 hover:bg-white/10"
+            >
+              <RefreshIcon className="h-4 w-4" />
+            </button>
+          </div>
+
+          {!consented ? (
+            <div className="flex flex-1 flex-col items-center justify-center gap-4 px-8 text-center">
+              <ShieldCheckIcon className="h-8 w-8" />
+              <p className="text-base font-semibold">We value your privacy</p>
+              <p className="text-sm leading-relaxed text-white/50">
+                Messages are sent to our AI assistant to help answer your question. By continuing, you agree to our data policy.
+              </p>
+              <button
+                onClick={acceptConsent}
+                className="mt-2 rounded-full bg-white px-6 py-2.5 text-sm font-semibold text-black"
+              >
+                Accept &amp; Chat
+              </button>
+            </div>
+          ) : (
+            <>
+              <div ref={scrollRef} className="flex-1 space-y-3 overflow-y-auto px-4 py-4">
+                {messages.length === 0 ? (
+                  <div className="flex flex-col items-center pt-6 text-center">
+                    <div className="mb-4 flex h-14 w-14 items-center justify-center rounded-2xl border border-white/10 bg-white/5">
+                      <BotIcon className="h-7 w-7" />
+                    </div>
+                    <p className="text-sm text-white/50">{greetingForTime()} 👋</p>
+                    <p className="mt-1 text-xl font-semibold">Hey there!</p>
+                    <p className="mt-1 text-sm text-white/50">Ask me anything about SDGP projects.</p>
+
+                    <div className="mt-6 w-full space-y-2">
+                      {STARTER_PROMPTS.map((p) => (
+                        <button
+                          key={p}
+                          onClick={() => send(p)}
+                          className="block w-full rounded-xl border border-white/10 px-3 py-2.5 text-left text-sm hover:bg-white/5"
+                        >
+                          {p}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                ) : (
+                  messages.map((m, i) => (
+                    <div
+                      key={i}
+                      className={`max-w-[85%] rounded-2xl px-3.5 py-2.5 text-sm leading-relaxed ${
+                        m.role === "user" ? "ml-auto bg-white text-black" : "mr-auto bg-white/[0.06] text-white/90"
+                      }`}
+                    >
+                      {m.role === "assistant" ? (
+                        <ReactMarkdown
+                          components={{
+                            p: ({ ...props }) => <p className="mb-2 last:mb-0" {...props} />,
+                            ul: ({ ...props }) => <ul className="mb-2 list-disc space-y-1 pl-4 last:mb-0" {...props} />,
+                            ol: ({ ...props }) => <ol className="mb-2 list-decimal space-y-1 pl-4 last:mb-0" {...props} />,
+                            li: ({ ...props }) => <li {...props} />,
+                            strong: ({ ...props }) => <strong className="font-semibold text-white" {...props} />,
+                            a: ({ ...props }) => (
+                              <a className="text-blue-400 underline" target="_blank" rel="noopener noreferrer" {...props} />
+                            ),
+                          }}
+                        >
+                          {m.content}
+                        </ReactMarkdown>
+                      ) : (
+                        m.content
+                      )}
+                    </div>
+                  ))
+                )}
+
+                {loading && (
+                  <div className="mr-auto max-w-[85%] rounded-2xl bg-white/[0.06] px-3.5 py-2.5 text-sm text-white/90">
+                    Thinking…
+                  </div>
+                )}
+              </div>
+
+              <div className="border-t border-white/10 px-4 pb-3 pt-3">
+                {showTooltip && messages.length === 0 && (
+                  <div className="mb-2 flex items-center justify-between">
+                    <span className="flex items-center gap-1.5 text-xs text-white/50">
+                      <span className="h-1.5 w-1.5 rounded-full bg-emerald-400" />
+                      Type your question here
+                    </span>
+                    <button onClick={dismissTooltip} className="text-xs text-white/50 underline">
+                      skip
+                    </button>
+                  </div>
+                )}
+
+                <form
+                  onSubmit={(e) => {
+                    e.preventDefault();
+                    send(input);
+                  }}
+                  className="flex items-end gap-2"
+                >
+                  <div className="relative flex-1">
+                    <input
+                      value={input}
+                      onChange={(e) => setInput(e.target.value.slice(0, MAX_LEN))}
+                      placeholder="Message..."
+                      maxLength={MAX_LEN}
+                      className="w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-3 pr-14 text-sm text-white outline-none focus:border-blue-500"
+                    />
+                    <span className="pointer-events-none absolute bottom-1.5 right-3 text-[10px] text-white/50">
+                      {input.length}/{MAX_LEN}
+                    </span>
+                  </div>
+                  <button
+                    type="submit"
+                    disabled={loading}
+                    aria-label="Send"
+                    className="flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl bg-white text-black disabled:opacity-40"
+                  >
+                    <SendIcon className="h-4 w-4" />
+                  </button>
+                </form>
+
+                <p className="mt-2 text-center text-[11px] text-white/50">powered by SDGP.LK</p>
+              </div>
+            </>
+          )}
+        </div>
+      )}
+
+      {open && (
+        <button
+          onClick={() => setOpen(false)}
+          aria-label="Close chat"
+          className="fixed right-4 top-4 z-[10000] flex h-10 w-10 items-center justify-center rounded-full border border-white/10 bg-black/80 text-white sm:hidden"
+        >
+          <XIcon className="h-4 w-4" />
+        </button>
+      )}
+
+      <button
+        onClick={() => setOpen((v) => !v)}
+        aria-label="Toggle chat"
+        className={`${open ? "hidden sm:flex" : "flex"} mb-5 mr-5 h-14 w-14 items-center justify-center rounded-2xl border border-blue-500/50 bg-black text-white shadow-xl transition hover:scale-105 hover:border-blue-500 sm:mb-0 sm:mr-0`}
+      >
+        {open ? <XIcon className="h-5 w-5" /> : <BotIcon className="h-6 w-6" />}
+      </button>
+    </div>,
+    document.body
+  );
+}

--- a/components/ChatBot.tsx
+++ b/components/ChatBot.tsx
@@ -9,6 +9,7 @@ import { useState, useRef, useEffect } from "react";
 import { createPortal } from "react-dom";
 import Image from "next/image";
 import ReactMarkdown from "react-markdown";
+import { CONSENT_KEY, TOOLTIP_KEY, MAX_LEN } from "@/lib/constants/chat";
 
 type Message = { role: "user" | "assistant"; content: string };
 
@@ -96,10 +97,6 @@ function greetingForTime() {
   if (hour < 18) return "Good afternoon";
   return "Good evening";
 }
-
-const CONSENT_KEY = "sdgp_chat_consent";
-const TOOLTIP_KEY = "sdgp_chat_tooltip_dismissed";
-const MAX_LEN = 200;
 
 export default function ChatBot() {
   const [mounted, setMounted] = useState(false);
@@ -292,6 +289,7 @@ export default function ChatBot() {
                       value={input}
                       onChange={(e) => setInput(e.target.value.slice(0, MAX_LEN))}
                       placeholder="Message..."
+                      aria-label="Message"
                       maxLength={MAX_LEN}
                       className="w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-3 pr-14 text-sm text-white outline-none focus:border-blue-500"
                     />

--- a/components/ChatBot.tsx
+++ b/components/ChatBot.tsx
@@ -162,7 +162,7 @@ export default function ChatBot() {
         <div className="fixed inset-0 z-[9999] flex h-[100dvh] w-screen flex-col overflow-hidden bg-black text-white sm:static sm:z-auto sm:mb-3 sm:h-[min(600px,calc(100dvh-6rem))] sm:w-[380px] sm:rounded-3xl sm:border sm:border-white/10 sm:shadow-2xl sm:shadow-black/40">
           <div className="flex items-center justify-between border-b border-white/10 px-4 py-3.5">
             <div className="flex items-center gap-3">
-              <div className="flex h-9 w-9 items-center justify-center overflow-hidden rounded-xl border border-white/10 bg-white/5">
+              <div className="flex h-9 w-9 items-center justify-center overflow-hidden rounded-full border border-white/10 bg-white/5">
                 <Image
                   src={LOGO_SRC}
                   alt="Logo"
@@ -172,7 +172,7 @@ export default function ChatBot() {
                 />
               </div>
               <div>
-                <p className="text-sm font-semibold leading-tight">Assistant</p>
+                <p className="text-sm font-semibold leading-tight">SDGP Assistant</p>
                 <p className="flex items-center gap-1.5 text-xs text-white/50">
                   <span className="h-1.5 w-1.5 rounded-full bg-emerald-400" />
                   Online
@@ -207,7 +207,7 @@ export default function ChatBot() {
               <div ref={scrollRef} className="flex-1 space-y-3 overflow-y-auto px-4 py-4">
                 {messages.length === 0 ? (
                   <div className="flex flex-col items-center pt-6 text-center">
-                    <div className="mb-4 flex h-14 w-14 items-center justify-center rounded-2xl border border-white/10 bg-white/5">
+                    <div className="mb-4 flex h-14 w-14 items-center justify-center rounded-full border border-white/10 bg-white/5">
                       <BotIcon className="h-7 w-7" />
                     </div>
                     <p className="text-sm text-white/50">{greetingForTime()} 👋</p>
@@ -230,9 +230,8 @@ export default function ChatBot() {
                   messages.map((m, i) => (
                     <div
                       key={i}
-                      className={`max-w-[85%] rounded-2xl px-3.5 py-2.5 text-sm leading-relaxed ${
-                        m.role === "user" ? "ml-auto bg-white text-black" : "mr-auto bg-white/[0.06] text-white/90"
-                      }`}
+                      className={`max-w-[85%] rounded-2xl px-3.5 py-2.5 text-sm leading-relaxed ${m.role === "user" ? "ml-auto bg-white text-black" : "mr-auto bg-white/[0.06] text-white/90"
+                        }`}
                     >
                       {m.role === "assistant" ? (
                         <ReactMarkdown
@@ -325,7 +324,7 @@ export default function ChatBot() {
       <button
         onClick={() => setOpen((v) => !v)}
         aria-label="Toggle chat"
-        className={`${open ? "hidden sm:flex" : "flex"} mb-5 mr-5 h-14 w-14 items-center justify-center rounded-2xl border border-blue-500/50 bg-black text-white shadow-xl transition hover:scale-105 hover:border-blue-500 sm:mb-0 sm:mr-0`}
+        className={`${open ? "hidden sm:flex" : "flex"} mb-5 mr-5 h-14 w-14 items-center justify-center rounded-full border border-blue-500/50 bg-black text-white shadow-xl transition hover:scale-105 hover:border-blue-500 sm:mb-0 sm:mr-0`}
       >
         {open ? <XIcon className="h-5 w-5" /> : <BotIcon className="h-6 w-6" />}
       </button>

--- a/components/ChatBot.tsx
+++ b/components/ChatBot.tsx
@@ -1,3 +1,8 @@
+// © 2026 SDGP.lk
+// Licensed under the GNU Affero General Public License v3.0 or later,
+// with an additional restriction: Non-commercial use only.
+// See <https://www.gnu.org/licenses/agpl-3.0.html> for details.
+
 "use client";
 
 import { useState, useRef, useEffect } from "react";

--- a/components/Clientlayout.tsx
+++ b/components/Clientlayout.tsx
@@ -11,6 +11,7 @@ import { SpeedInsights } from "@vercel/speed-insights/next"
 import CookieBanner from "@/components/CookieBanner"
 import { usePathname } from "next/navigation";
 import { SessionProvider } from "next-auth/react";
+import ChatBot from "@/components/ChatBot";
 
 export default function ClientLayout({ children }: { children: React.ReactNode }) {
   const isMobile = useIsMobile();
@@ -30,6 +31,7 @@ export default function ClientLayout({ children }: { children: React.ReactNode }
       <Analytics />
       <SpeedInsights />
       <Toaster />
+      <ChatBot />
     </ThemeProvider>
   );
 }

--- a/components/Cursor.tsx
+++ b/components/Cursor.tsx
@@ -121,7 +121,7 @@ export function CustomCursor() {
     <>
       {/* Main cursor */}
       <div
-        className={`fixed pointer-events-none z-50 transition-opacity duration-300 ${
+        className={`fixed pointer-events-none z-[10050] transition-opacity duration-300 ${
           hidden ? "opacity-0" : "opacity-100"
         }`}
         style={{
@@ -156,7 +156,7 @@ export function CustomCursor() {
 
       {/* Trailing circle with delay */}
       <div
-        className="fixed pointer-events-none z-40 opacity-30 rounded-full"
+        className="fixed pointer-events-none z-[10040] opacity-30 rounded-full"
         style={{
           left: `${trailPosition.x}px`,
           top: `${trailPosition.y}px`,

--- a/lib/constants/chat.ts
+++ b/lib/constants/chat.ts
@@ -1,0 +1,3 @@
+export const CONSENT_KEY = "sdgp_chat_consent";
+export const TOOLTIP_KEY = "sdgp_chat_tooltip_dismissed";
+export const MAX_LEN = 200;

--- a/lib/constants/groq.ts
+++ b/lib/constants/groq.ts
@@ -1,0 +1,24 @@
+import Groq from "groq-sdk";
+
+export const groq = new Groq({ apiKey: process.env.GROQ_API_KEY });
+
+export const MODEL = "openai/gpt-oss-120b";
+
+export const MAX_HISTORY_MESSAGES = 8;
+export const MAX_MESSAGES = 40;
+export const MAX_MESSAGE_LENGTH = 4000;
+
+export const QUOTA_EXCEEDED_MESSAGE =
+  "I've hit today's usage limit. Please try again later.";
+
+export const SYSTEM_PROMPT = `You are the assistant embedded on SDGP.lk, a directory of student software/hardware projects (AI, ML, healthtech, fintech, edtech, and more).
+
+Rules:
+- For any question about specific projects, teams, domains, tech stacks, SDG goals, or "best/featured" projects, ALWAYS call the search_projects tool first. Never invent project details.
+- If the tool returns no results, say so plainly and don't make something up.
+- If the user asks for an idea, inspiration, or "what should I build" (rather than asking about existing projects), you MUST do two things, in this order:
+  1. Call search_projects and list 1-3 relevant existing projects under a heading like "Similar projects already on SDGP.lk", each with its View Project link — for context/inspiration only.
+  2. Then propose at least one genuinely NEW idea, under a heading like "An idea you could build", that is NOT one of the projects returned by search_projects. Base it on gaps you notice in the search results or general domain knowledge, and describe it in 2-3 sentences.
+  Never present an existing project as if it were a suggestion for the user to go build.
+- Keep answers concise. For each project you mention, write its title as plain text (do NOT turn the title itself into a markdown link), then include a separate "View Project" link using its pageUrl field, e.g.: "BlynQ. — An AI Powered Vehicle Management System. [View Project](pageUrl)". Never use the website field, and never link the same pageUrl twice in one line.
+- Never reveal internal fields like emails, phone numbers, or unapproved/pending projects — the tool already filters these out, so just don't speculate beyond what it returns.`;

--- a/lib/projectSearch.ts
+++ b/lib/projectSearch.ts
@@ -23,6 +23,8 @@ export interface ProjectSearchParams {
   limit?: number;
 }
 
+const HARD_FETCH_CAP = 100;
+
 export async function searchProjects(params: ProjectSearchParams | null | undefined) {
   const {
     keyword,
@@ -35,7 +37,8 @@ export async function searchProjects(params: ProjectSearchParams | null | undefi
     limit = 3,
   } = params ?? {};
 
-  const take = Math.min(limit, 8);
+  const rawLimit = Number.isFinite(limit) ? Math.floor(limit as number) : 3;
+  const take = Math.min(Math.max(rawLimit, 1), 8);
 
   const associationFilters: Record<string, unknown>[] = [];
   if (domain) associationFilters.push({ type: "PROJECT_DOMAIN", domain });
@@ -49,9 +52,19 @@ export async function searchProjects(params: ProjectSearchParams | null | undefi
   const candidates = await prisma.projectMetadata.findMany({
     where: {
       ...(featuredOnly ? { featured: true } : {}),
+      ...(keyword
+        ? {
+            OR: [
+              { title: { contains: keyword, mode: "insensitive" } },
+              { subtitle: { contains: keyword, mode: "insensitive" } },
+            ],
+          }
+        : {}),
       projectContent: {
-        status: { approved_status: "APPROVED" },
-        ...(status ? { status: { status } } : {}),
+        status: {
+          approved_status: "APPROVED",
+          ...(status ? { status } : {}),
+        },
         ...(associationFilters.length
           ? {
               AND: associationFilters.map((f) => ({
@@ -76,7 +89,8 @@ export async function searchProjects(params: ProjectSearchParams | null | undefi
         },
       },
     },
-    orderBy: { featured: "desc" },
+    orderBy: [{ featured: "desc" }, { project_id: "asc" }],
+    take: HARD_FETCH_CAP,
   });
 
   const filtered = normalizedKeyword

--- a/lib/projectSearch.ts
+++ b/lib/projectSearch.ts
@@ -1,3 +1,8 @@
+// © 2026 SDGP.lk
+// Licensed under the GNU Affero General Public License v3.0 or later,
+// with an additional restriction: Non-commercial use only.
+// See <https://www.gnu.org/licenses/agpl-3.0.html> for details.
+
 import { prisma } from "@/prisma/prismaClient";
 import {
   ProjectDomainEnum,

--- a/lib/projectSearch.ts
+++ b/lib/projectSearch.ts
@@ -18,9 +18,7 @@ export interface ProjectSearchParams {
   limit?: number;
 }
 
-// Only ever return content that has passed moderation. Never leak PENDING/REJECTED
-// projects or internal fields (team emails/phones) to the public-facing chatbot.
-export async function searchProjects(params: ProjectSearchParams) {
+export async function searchProjects(params: ProjectSearchParams | null | undefined) {
   const {
     keyword,
     domain,
@@ -29,8 +27,10 @@ export async function searchProjects(params: ProjectSearchParams) {
     sdgGoal,
     status,
     featuredOnly,
-    limit = 5,
-  } = params;
+    limit = 3,
+  } = params ?? {};
+
+  const take = Math.min(limit, 8);
 
   const associationFilters: Record<string, unknown>[] = [];
   if (domain) associationFilters.push({ type: "PROJECT_DOMAIN", domain });
@@ -38,17 +38,12 @@ export async function searchProjects(params: ProjectSearchParams) {
   if (projectType) associationFilters.push({ type: "PROJECT_TYPE", projectType });
   if (sdgGoal) associationFilters.push({ type: "PROJECT_SDG", sdgGoal });
 
-  const results = await prisma.projectMetadata.findMany({
+  const normalize = (s: string) => s.toLowerCase().replace(/[^a-z0-9]/g, "");
+  const normalizedKeyword = keyword ? normalize(keyword) : "";
+
+  const candidates = await prisma.projectMetadata.findMany({
     where: {
       ...(featuredOnly ? { featured: true } : {}),
-      ...(keyword
-        ? {
-            OR: [
-              { title: { contains: keyword } },
-              { subtitle: { contains: keyword } },
-            ],
-          }
-        : {}),
       projectContent: {
         status: { approved_status: "APPROVED" },
         ...(status ? { status: { status } } : {}),
@@ -65,8 +60,6 @@ export async function searchProjects(params: ProjectSearchParams) {
       project_id: true,
       title: true,
       subtitle: true,
-      website: true,
-      cover_image: true,
       featured: true,
       sdgp_year: true,
       projectContent: {
@@ -75,26 +68,28 @@ export async function searchProjects(params: ProjectSearchParams) {
           associations: {
             select: { type: true, domain: true, techStack: true, sdgGoal: true, projectType: true },
           },
-          projectDetails: {
-            select: { problem_statement: true, solution: true, features: true },
-          },
         },
       },
     },
-    take: Math.min(limit, 10),
     orderBy: { featured: "desc" },
   });
 
-  // Flatten into a compact shape — keeps the token cost of tool_result low
-  // and strips anything not meant for public consumption (no team_email/phone).
+  const filtered = normalizedKeyword
+    ? candidates.filter(
+        (p) =>
+          normalize(p.title ?? "").includes(normalizedKeyword) ||
+          normalize(p.subtitle ?? "").includes(normalizedKeyword)
+      )
+    : candidates;
+
+  const results = filtered.slice(0, take);
+
   return results.map((p) => ({
     id: p.project_id,
     title: p.title,
     subtitle: p.subtitle,
-    website: p.website,
-    year: p.sdgp_year,
+    pageUrl: `/project/${p.project_id}`,
     featured: p.featured,
-    status: p.projectContent?.status?.status ?? null,
     domains: p.projectContent?.associations
       .filter((a) => a.type === "PROJECT_DOMAIN")
       .map((a) => a.domain),
@@ -104,7 +99,5 @@ export async function searchProjects(params: ProjectSearchParams) {
     sdgGoals: p.projectContent?.associations
       .filter((a) => a.type === "PROJECT_SDG")
       .map((a) => a.sdgGoal),
-    solution: p.projectContent?.projectDetails?.solution ?? null,
-    features: p.projectContent?.projectDetails?.features ?? null,
   }));
 }

--- a/lib/projectSearch.ts
+++ b/lib/projectSearch.ts
@@ -1,0 +1,110 @@
+import { prisma } from "@/prisma/prismaClient";
+import {
+  ProjectDomainEnum,
+  ProjectTypeEnum,
+  SDGGoalEnum,
+  TechStackEnum,
+  ProjectStatusEnum,
+} from "@prisma/client";
+
+export interface ProjectSearchParams {
+  keyword?: string;
+  domain?: ProjectDomainEnum;
+  techStack?: TechStackEnum;
+  projectType?: ProjectTypeEnum;
+  sdgGoal?: SDGGoalEnum;
+  status?: ProjectStatusEnum;
+  featuredOnly?: boolean;
+  limit?: number;
+}
+
+// Only ever return content that has passed moderation. Never leak PENDING/REJECTED
+// projects or internal fields (team emails/phones) to the public-facing chatbot.
+export async function searchProjects(params: ProjectSearchParams) {
+  const {
+    keyword,
+    domain,
+    techStack,
+    projectType,
+    sdgGoal,
+    status,
+    featuredOnly,
+    limit = 5,
+  } = params;
+
+  const associationFilters: Record<string, unknown>[] = [];
+  if (domain) associationFilters.push({ type: "PROJECT_DOMAIN", domain });
+  if (techStack) associationFilters.push({ type: "PROJECT_TECH", techStack });
+  if (projectType) associationFilters.push({ type: "PROJECT_TYPE", projectType });
+  if (sdgGoal) associationFilters.push({ type: "PROJECT_SDG", sdgGoal });
+
+  const results = await prisma.projectMetadata.findMany({
+    where: {
+      ...(featuredOnly ? { featured: true } : {}),
+      ...(keyword
+        ? {
+            OR: [
+              { title: { contains: keyword } },
+              { subtitle: { contains: keyword } },
+            ],
+          }
+        : {}),
+      projectContent: {
+        status: { approved_status: "APPROVED" },
+        ...(status ? { status: { status } } : {}),
+        ...(associationFilters.length
+          ? {
+              AND: associationFilters.map((f) => ({
+                associations: { some: f },
+              })),
+            }
+          : {}),
+      },
+    },
+    select: {
+      project_id: true,
+      title: true,
+      subtitle: true,
+      website: true,
+      cover_image: true,
+      featured: true,
+      sdgp_year: true,
+      projectContent: {
+        select: {
+          status: { select: { status: true } },
+          associations: {
+            select: { type: true, domain: true, techStack: true, sdgGoal: true, projectType: true },
+          },
+          projectDetails: {
+            select: { problem_statement: true, solution: true, features: true },
+          },
+        },
+      },
+    },
+    take: Math.min(limit, 10),
+    orderBy: { featured: "desc" },
+  });
+
+  // Flatten into a compact shape — keeps the token cost of tool_result low
+  // and strips anything not meant for public consumption (no team_email/phone).
+  return results.map((p) => ({
+    id: p.project_id,
+    title: p.title,
+    subtitle: p.subtitle,
+    website: p.website,
+    year: p.sdgp_year,
+    featured: p.featured,
+    status: p.projectContent?.status?.status ?? null,
+    domains: p.projectContent?.associations
+      .filter((a) => a.type === "PROJECT_DOMAIN")
+      .map((a) => a.domain),
+    techStack: p.projectContent?.associations
+      .filter((a) => a.type === "PROJECT_TECH")
+      .map((a) => a.techStack),
+    sdgGoals: p.projectContent?.associations
+      .filter((a) => a.type === "PROJECT_SDG")
+      .map((a) => a.sdgGoal),
+    solution: p.projectContent?.projectDetails?.solution ?? null,
+    features: p.projectContent?.projectDetails?.features ?? null,
+  }));
+}

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "embla-carousel-react": "^8.6.0",
     "formidable": "^3.5.2",
     "framer-motion": "^12.23.12",
+    "groq-sdk": "^1.3.0",
     "headlessui": "^0.0.0",
     "i": "^0.3.7",
     "install": "^0.13.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3313,6 +3313,11 @@ graphemer@^1.4.0:
   resolved "https://registry.yarnpkg.com/graphemer/-/graphemer-1.4.0.tgz#fb2f1d55e0e3a1849aeffc90c4fa0dd53a0e66c6"
   integrity sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==
 
+groq-sdk@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/groq-sdk/-/groq-sdk-1.3.0.tgz#0ae713f5e224b4ad62efd95aaebb92b7fd9408b5"
+  integrity sha512-mvgUIpAxlk/VxWIoliHx4R+Ha78Bd/g0t24OFjCXtdLbNiY1rW4h9AcznKBwFho7K/Nq732ZSjxMYkNb1xeCFg==
+
 h3-js@4:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/h3-js/-/h3-js-4.4.0.tgz#858586205d49fc2b164df8e2d1ab855565ee9e81"


### PR DESCRIPTION
## How it works

When a user sends a message, it goes to the Groq LLM (`llama-3.3-70b-versatile`) along with a description of one tool it can call, `search_projects`. The LLM reads the question and decides which filters apply (domain, tech stack, SDG goal, keyword, etc.), then calls the tool with those values as plain arguments. The LLM never writes or sees SQL.

`search_projects` is ordinary TypeScript code that takes those filters and builds a Prisma query against MySQL. It starts from `ProjectMetadata` (title, subtitle, featured flag), joins to `ProjectContent` to enforce that only approved projects are ever considered, and joins to an `associations` table to match on domain, tech stack, project type, or SDG goal, since each project can have several of each.

MySQL runs the query and returns matching rows, which get reshaped into a small, safe JSON object per project (title, subtitle, a `pageUrl`, and its domain/tech/SDG tags). Sensitive fields like emails are never selected in the first place, so they can't leak.

That JSON goes back to the LLM, which writes the final reply using the project titles and links per the system prompt's formatting rules.

The AI only touches the two ends of the process, interpreting the question and phrasing the answer. The database lookup in between is fully deterministic code with no AI involved.