### PR TITLE
Feature: Add Investment 

### DIFF
--- a/app/(public)/project/page.tsx
+++ b/app/(public)/project/page.tsx
@@ -23,6 +23,7 @@ const ThreeScene = dynamic(() => import("@/components/home/three-scene"), {
 
 interface FilterState {
     featured: boolean;
+    investment: boolean;
     status: string[];
     years: string[];
     projectTypes: string[];
@@ -43,6 +44,7 @@ function ProjectsPageContent() {
         limit: parseInt(searchParams.get('limit') || '9', 10),
         title: searchParams.get('title') || undefined,
         featured: searchParams.get('featured') === 'true',
+        investment: searchParams.get('investment') === 'true',
         status: searchParams.getAll('status'),
         years: searchParams.getAll('years'),
         projectTypes: searchParams.getAll('projectTypes'),
@@ -66,6 +68,7 @@ function ProjectsPageContent() {
 
     const initialFilters = useMemo((): FilterState => ({
         featured: currentParams.featured || false,
+        investment: currentParams.investment || false,
         status: currentParams.status || [],
         years: currentParams.years || [],
         projectTypes: currentParams.projectTypes || [],
@@ -89,6 +92,7 @@ function ProjectsPageContent() {
         const prev = prevFiltersRef.current;
         const isSame =
             prev.featured === newFilters.featured &&
+            prev.investment === newFilters.investment &&
             JSON.stringify([...prev.status].sort()) === JSON.stringify([...newFilters.status].sort()) &&
             JSON.stringify([...prev.years].sort()) === JSON.stringify([...newFilters.years].sort()) &&
             JSON.stringify([...prev.projectTypes].sort()) === JSON.stringify([...newFilters.projectTypes].sort()) &&
@@ -112,6 +116,8 @@ function ProjectsPageContent() {
         if (newFilters.featured) {
             params.append('featured', 'true');
         }
+
+        if (newFilters.investment) params.append('investment', 'true');
 
         // Handle array filters
         Object.entries(newFilters).forEach(([key, values]) => {

--- a/app/api/projects/route.ts
+++ b/app/api/projects/route.ts
@@ -18,6 +18,7 @@ export const GET = async (req: NextRequest) => {
 
     // --- Filters from URL ---
     const title        = searchParams.get("title")    || "";
+    const investment   = searchParams.get("investment") === "true";
     const years        = searchParams.getAll("years");
     const statusValues = searchParams.getAll("status");
     const projectTypes = searchParams.getAll("projectTypes");
@@ -31,6 +32,10 @@ export const GET = async (req: NextRequest) => {
     // Year filter
     if (years.length) {
       baseWhere.sdgp_year = { in: years };
+    }
+
+    if (investment) {
+      baseWhere.lookingForInvestment = true;
     }
 
     // Status filter

--- a/app/api/student/projects/[projectId]/route.ts
+++ b/app/api/student/projects/[projectId]/route.ts
@@ -143,3 +143,66 @@ export async function GET(
     );
   }
 }
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ projectId: string }> }
+) {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const role = (session.user as any)?.role as Role | undefined;
+    if (role !== Role.STUDENT) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    const userId = (session.user as any)?.id as string | undefined;
+    if (!userId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { projectId } = await params;
+    if (!projectId) {
+      return NextResponse.json({ error: "Project ID is required" }, { status: 400 });
+    }
+
+    const body = await request.json();
+    if (typeof body?.lookingForInvestment !== "boolean") {
+      return NextResponse.json(
+        { error: "lookingForInvestment must be a boolean" },
+        { status: 400 }
+      );
+    }
+
+    const projectMetadata = await prisma.projectMetadata.findUnique({
+      where: { project_id: projectId },
+      select: { project_id: true, owner_userId: true },
+    });
+
+    if (!projectMetadata || projectMetadata.owner_userId !== userId) {
+      return NextResponse.json({ error: "Project not found" }, { status: 404 });
+    }
+
+    const updated = await prisma.projectMetadata.update({
+      where: { project_id: projectId },
+      data: { lookingForInvestment: body.lookingForInvestment },
+      select: { project_id: true, lookingForInvestment: true },
+    });
+
+    return NextResponse.json({
+      data: {
+        projectId: updated.project_id,
+        lookingForInvestment: updated.lookingForInvestment,
+      },
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    return NextResponse.json(
+      { error: "Failed to update investment status", details: message },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/student/projects/route.ts
+++ b/app/api/student/projects/route.ts
@@ -69,6 +69,7 @@ export async function GET(request: Request) {
       approvalStatus: p.projectContent?.status?.approved_status ?? null,
       rejectedReason: p.projectContent?.status?.rejected_reason ?? null,
       pendingEdit: pendingSet.has(p.project_id),
+      lookingForInvestment: p.lookingForInvestment,
     }));
 
     return NextResponse.json({

--- a/components/ProjectDetails.tsx
+++ b/components/ProjectDetails.tsx
@@ -67,6 +67,7 @@ const ProjectDetails = ({ projectID }: { projectID: string }) => {
             )
             .map((association) => association.domain)}
           status={project.content?.status?.status}
+          lookingForInvestment={project.metadata.lookingForInvestment}
           logo={project.metadata.logo}
           website={project.metadata.website}
           projectId={project.metadata.project_id}

--- a/components/StudentProjectsClient.tsx
+++ b/components/StudentProjectsClient.tsx
@@ -14,6 +14,7 @@ import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Skeleton } from '@/components/ui/skeleton'
+import { Switch } from '@/components/ui/switch'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
 
 type StudentProjectRow = {
@@ -24,6 +25,7 @@ type StudentProjectRow = {
     approvalStatus: string | null
     rejectedReason: string | null
     pendingEdit: boolean
+    lookingForInvestment: boolean | null
 }
 
 export default function StudentProjectsClient() {
@@ -32,6 +34,7 @@ export default function StudentProjectsClient() {
     const [projects, setProjects] = useState<StudentProjectRow[]>([])
     const [isLoading, setIsLoading] = useState(true)
     const [errorMessage, setErrorMessage] = useState<string | null>(null)
+    const [updatingProjectId, setUpdatingProjectId] = useState<string | null>(null)
 
     useEffect(() => {
         const load = async () => {
@@ -52,6 +55,32 @@ export default function StudentProjectsClient() {
         }
         load()
     }, [])
+
+    const handleInvestmentToggle = async (projectId: string, checked: boolean) => {
+        setUpdatingProjectId(projectId)
+        setErrorMessage(null)
+
+        const previousProjects = projects
+
+        setProjects((current) =>
+            current.map((project) =>
+                project.projectId === projectId
+                    ? { ...project, lookingForInvestment: checked }
+                    : project
+            )
+        )
+
+        try {
+            await axios.patch(`/api/student/projects/${projectId}`, {
+                lookingForInvestment: checked,
+            })
+        } catch (e: any) {
+            setProjects(previousProjects)
+            setErrorMessage(e?.response?.data?.error || e.message || 'Failed to update investment status')
+        } finally {
+            setUpdatingProjectId(null)
+        }
+    }
 
     if (isLoading) {
         return (
@@ -90,6 +119,7 @@ export default function StudentProjectsClient() {
                     <TableHead>Group</TableHead>
                     <TableHead>Year</TableHead>
                     <TableHead>Status</TableHead>
+                    <TableHead>Investment</TableHead>
                     <TableHead>Pending Edit</TableHead>
                     <TableHead className='text-right'>Actions</TableHead>
                 </TableRow>
@@ -113,6 +143,20 @@ export default function StudentProjectsClient() {
                                 >
                                     {p.approvalStatus ?? 'UNKNOWN'}
                                 </Badge>
+                            </TableCell>
+                            <TableCell>
+                                <div className='flex items-center gap-3'>
+                                    <Switch
+                                        checked={p.lookingForInvestment ?? false}
+                                        disabled={updatingProjectId === p.projectId}
+                                        onCheckedChange={(checked) =>
+                                            handleInvestmentToggle(p.projectId, checked)
+                                        }
+                                    />
+                                    <span className='text-sm text-muted-foreground'>
+                                        {p.lookingForInvestment ? 'Yes' : 'No'}
+                                    </span>
+                                </div>
                             </TableCell>
                             <TableCell>
                                 {p.pendingEdit ? (
@@ -139,7 +183,7 @@ export default function StudentProjectsClient() {
                         </TableRow>
                         {p.approvalStatus === ProjectApprovalStatus.REJECTED && p.rejectedReason ? (
                             <TableRow key={`${p.projectId}-reason`}>
-                                <TableCell colSpan={6} className='bg-destructive/5 text-sm'>
+                                <TableCell colSpan={7} className='bg-destructive/5 text-sm'>
                                     <span className='font-medium text-destructive'>Rejected reason:</span>{' '}
                                     <span className='text-muted-foreground'>{p.rejectedReason}</span>
                                 </TableCell>

--- a/components/projects/filter-sidebar.tsx
+++ b/components/projects/filter-sidebar.tsx
@@ -33,6 +33,7 @@ type Option = {
 // Define the structure for the entire filter state
 export interface FilterState {
   featured: boolean; // Add featured filter
+  investment: boolean;
   status: string[];
   years: string[];
   projectTypes: string[];
@@ -43,6 +44,11 @@ export interface FilterState {
 
 // --- FeaturedFilterSection Component ---
 type FeaturedSectionProps = {
+  selection: boolean;
+  setSelection: React.Dispatch<React.SetStateAction<boolean>>;
+};
+
+type InvestmentSectionProps = {
   selection: boolean;
   setSelection: React.Dispatch<React.SetStateAction<boolean>>;
 };
@@ -79,6 +85,43 @@ function FeaturedFilterSection({
             />
             <Label htmlFor="featured" className="flex-grow truncate text-sm cursor-pointer">
               Featured 
+            </Label>
+          </div>
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}
+
+function InvestmentFilterSection({ selection, setSelection }: InvestmentSectionProps) {
+  const [isOpen, setIsOpen] = useState(true);
+
+  const toggleInvestment = useCallback(() => {
+    setSelection(prev => !prev);
+  }, [setSelection]);
+
+  return (
+    <Collapsible open={isOpen} onOpenChange={setIsOpen} className="w-full">
+      <CollapsibleTrigger asChild>
+        <Button
+          variant="ghost"
+          className="flex w-full justify-between p-2 font-medium hover:bg-muted/50"
+        >
+          Investment
+          <ChevronDown className={cn("h-4 w-4 transition-transform", isOpen && "rotate-180")} />
+        </Button>
+      </CollapsibleTrigger>
+      <CollapsibleContent className="px-2 data-[state=open]:animate-collapsible-down data-[state=closed]:animate-collapsible-up overflow-hidden">
+        <div className="pt-1 pb-2 space-y-1">
+          <div className="flex items-center gap-2 px-1 py-1">
+            <Checkbox
+              id="investment"
+              checked={selection}
+              onCheckedChange={toggleInvestment}
+              className="flex-shrink-0"
+            />
+            <Label htmlFor="investment" className="flex-grow truncate text-sm cursor-pointer">
+              Open for Investment
             </Label>
           </div>
         </div>
@@ -296,6 +339,7 @@ export default function FilterSidebar({
 }: FilterSidebarProps) {
   // Internal state for each filter category, initialized from props
   const [featuredOnly, setFeaturedOnly] = useState<boolean>(() => initialFilters.featured || false);
+  const [openForInvestment, setOpenForInvestment] = useState<boolean>(() => initialFilters.investment || false);
   const [selectedStatuses, setSelectedStatuses] = useState<string[]>(() => initialFilters.status || []);
   const [selectedYears, setSelectedYears] = useState<string[]>(() => initialFilters.years || []);
   const [selectedProjectTypes, setSelectedProjectTypes] = useState<string[]>(() => initialFilters.projectTypes || []);
@@ -313,6 +357,7 @@ export default function FilterSidebar({
   const notifyFilterChange = useCallback(() => {
     onFilterChangeRef.current({
       featured: featuredOnly,
+      investment: openForInvestment,
       status: selectedStatuses,
       years: selectedYears,
       projectTypes: selectedProjectTypes,
@@ -322,6 +367,7 @@ export default function FilterSidebar({
     });
   }, [
     featuredOnly,
+    openForInvestment,
     selectedStatuses,
     selectedYears,
     selectedProjectTypes,
@@ -358,6 +404,9 @@ export default function FilterSidebar({
 
     if (initialFilters.featured !== featuredOnly) {
       setFeaturedOnly(initialFilters.featured || false);
+    }
+    if (initialFilters.investment !== openForInvestment) {
+      setOpenForInvestment(initialFilters.investment || false);
     }
     if (!arraysAreEqual(initialFilters.status, selectedStatuses)) {
       setSelectedStatuses(initialFilters.status || []);
@@ -422,6 +471,10 @@ export default function FilterSidebar({
     if (featuredOnly) {
       filters.push({ type: 'featured' as keyof FilterState, value: 'true', label: 'Featured Only' });
     }
+
+    if (openForInvestment) {
+      filters.push({ type: 'investment' as keyof FilterState, value: 'true', label: 'Open for Investment' });
+    }
     
     // Add other filters
     filters.push(
@@ -434,7 +487,7 @@ export default function FilterSidebar({
     );
     
     return filters;
-  }, [featuredOnly, selectedStatuses, selectedYears, selectedProjectTypes, selectedDomains, selectedSDGs, selectedTechStack, labelMap]);
+  }, [featuredOnly, openForInvestment, selectedStatuses, selectedYears, selectedProjectTypes, selectedDomains, selectedSDGs, selectedTechStack, labelMap]);
 
   const hasActiveFilters = activeFiltersList.length > 0;
 
@@ -443,6 +496,7 @@ export default function FilterSidebar({
   // Callback to clear all filters internally
   const clearFilters = useCallback(() => {
     setFeaturedOnly(false);
+    setOpenForInvestment(false);
     setSelectedStatuses([]);
     setSelectedYears([]);
     setSelectedProjectTypes([]);
@@ -456,6 +510,11 @@ export default function FilterSidebar({
   const removeFilter = useCallback((filterType: keyof FilterState, filterValue: string) => {
     if (filterType === 'featured') {
       setFeaturedOnly(false);
+      return;
+    }
+
+    if (filterType === 'investment') {
+      setOpenForInvestment(false);
       return;
     }
 
@@ -512,6 +571,10 @@ export default function FilterSidebar({
         <FeaturedFilterSection
           selection={featuredOnly}
           setSelection={setFeaturedOnly}
+        />
+        <InvestmentFilterSection
+          selection={openForInvestment}
+          setSelection={setOpenForInvestment}
         />
         <GenericFilterSection
           title="Project Status"

--- a/components/s-project/project-header.tsx
+++ b/components/s-project/project-header.tsx
@@ -17,6 +17,7 @@ interface ProjectHeaderProps {
   subtitle?: string;
   domains?: ProjectDomainEnum[];
   status?: ProjectStatusEnum;
+  lookingForInvestment?: boolean | null;
   logo?: string;
   website?: string;
   projectId: string;
@@ -27,6 +28,7 @@ export const ProjectHeader: React.FC<ProjectHeaderProps> = ({
   subtitle,
   domains,
   status,
+  lookingForInvestment,
   logo,
   website,
   projectId,
@@ -72,6 +74,11 @@ export const ProjectHeader: React.FC<ProjectHeaderProps> = ({
       <p className="text-lg md:text-xl text-gray-300 mb-4">{subtitle}</p>
 
       <div className="flex flex-wrap items-center gap-2 mb-6">
+        {lookingForInvestment ? (
+          <Badge>
+            OPEN FOR INVESTMENT
+          </Badge>
+        ) : null}
         <Badge>{status}</Badge>
         {domains?.map((domain) => (
           <Badge key={domain} variant="secondary">

--- a/hooks/project/useGetProjects.ts
+++ b/hooks/project/useGetProjects.ts
@@ -40,6 +40,10 @@ function useProjects(currentParams: ProjectQueryParams) {
         if (currentParams.title)
           queryParams.append("title", currentParams.title);
 
+        if (currentParams.investment) {
+          queryParams.append("investment", "true");
+        }
+
         if (currentParams.projectTypes?.length) {
           currentParams.projectTypes.forEach((type) =>
             queryParams.append("projectTypes", type),
@@ -165,6 +169,7 @@ function useProjects(currentParams: ProjectQueryParams) {
   useEffect(() => {
     const filterKey = [
       currentParams.featured,
+      currentParams.investment,
       currentParams.title,
       currentParams.limit,
       currentParams.projectTypes?.join(","),
@@ -186,6 +191,7 @@ function useProjects(currentParams: ProjectQueryParams) {
     };
   }, [
     currentParams.featured,
+    currentParams.investment,
     currentParams.page,
     currentParams.title,
     currentParams.limit,
@@ -214,6 +220,7 @@ export interface ProjectQueryParams {
   title?: string;
   projectTypes?: string[];
   featured?: boolean;
+  investment?: boolean;
   domains?: string[];
   status?: string[];
   sdgGoals?: string[];

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -270,6 +270,7 @@ model ProjectMetadata {
   cover_image        String?
   logo               String?
   featured           Boolean         @default(false)
+  lookingForInvestment Boolean?
   awards             Award[]         @relation("ProjectAwards")
   module             String?
 

--- a/types/project/type.ts
+++ b/types/project/type.ts
@@ -21,6 +21,7 @@ export interface IProjectMetadata {
     cover_image?: string;
     logo?: string;
     featured: boolean;
+    lookingForInvestment?: boolean | null;
     featured_by_userId?: string;
     createdAt?: Date;
     updatedAt?: Date;


### PR DESCRIPTION
Adds an `investment` filter across the public projects page, query hook, and API, and exposes `lookingForInvestment` in project metadata. Student project management now supports toggling investment status, and project details/header show the investment badge when enabled. The Prisma schema and shared project types were updated to match.